### PR TITLE
[ON HOLD] Cleanup model names in landing screen

### DIFF
--- a/moxin-frontend/src/landing/model_card.rs
+++ b/moxin-frontend/src/landing/model_card.rs
@@ -1,7 +1,7 @@
 use crate::data::store::{ModelWithPendingDownloads, Store};
 use crate::shared::external_link::ExternalLinkWidgetExt;
 use crate::shared::modal::ModalAction;
-use crate::shared::utils::hugging_face_model_url;
+use crate::shared::utils::{hugging_face_model_url, human_readable_model_name};
 use makepad_widgets::*;
 use moxin_protocol::data::ModelID;
 use unicode_segmentation::UnicodeSegmentation;
@@ -342,7 +342,7 @@ impl Widget for ModelCard {
 
         self.model_id = model.id.clone();
 
-        let name = &model.name;
+        let name = &human_readable_model_name(&model.name);
         self.label(id!(model_name)).set_text(name);
 
         let download_count = &model.download_count;

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -5,7 +5,10 @@ use moxin_protocol::data::{DownloadedFile, FileID};
 
 use crate::{
     data::store::Store,
-    shared::{modal::ModalAction, utils::format_model_size},
+    shared::{
+        modal::ModalAction,
+        utils::{format_model_size, human_readable_model_name},
+    },
 };
 
 use super::{
@@ -315,7 +318,7 @@ impl Widget for DownloadedFilesTable {
                             .insert(item.widget_uid().0, file_data.file.id.clone());
 
                         // Name tag
-                        let name = human_readable_name(&file_data.file.name);
+                        let name = human_readable_model_name(&file_data.file.name);
                         item.label(id!(h_wrapper.model_file.h_wrapper.name_tag.name))
                             .set_text(&name);
 
@@ -587,29 +590,6 @@ pub enum DownloadedFileAction {
     StartChat(FileID),
     ResumeChat(FileID),
     None,
-}
-
-/// Removes dashes, file extension, and capitalizes the first letter of each word.
-fn human_readable_name(name: &str) -> String {
-    let name = name
-        .to_lowercase()
-        .replace("-", " ")
-        .replace(".gguf", "")
-        .replace("chat", "");
-
-    let name = name
-        .split_whitespace()
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                None => String::new(),
-                Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
-            }
-        })
-        .collect::<Vec<String>>()
-        .join(" ");
-
-    name
 }
 
 fn dash_if_empty(input: &str) -> &str {

--- a/moxin-frontend/src/my_models/my_models_screen.rs
+++ b/moxin-frontend/src/my_models/my_models_screen.rs
@@ -238,7 +238,7 @@ impl WidgetMatchEvent for MyModelsScreen {
                 let models_uri = &format!("file:///.{}", models_dir);
                 robius_open::Uri::new(models_uri)
                     .open()
-                    .unwrap_or_else(|e| {
+                    .unwrap_or_else(|_e| {
                         eprintln!(
                             "Failed to open models downloads folder: {}. Check for permissions.",
                             models_uri

--- a/moxin-frontend/src/shared/utils.rs
+++ b/moxin-frontend/src/shared/utils.rs
@@ -26,3 +26,27 @@ pub fn format_model_downloaded_size(size: &str, progress: f64) -> Result<String>
 pub fn hugging_face_model_url(model_id: &str) -> String {
     format!("{}/{}", HUGGING_FACE_BASE_URL, model_id)
 }
+
+/// Removes dashes, file extension, and capitalizes the first letter of each word.
+pub fn human_readable_model_name(name: &str) -> String {
+    let name = name
+        .to_lowercase()
+        .replace("-", " ")
+        .replace("gguf", "")
+        .replace(".gguf", "")
+        .replace("chat", "");
+
+    let name = name
+        .split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(" ");
+
+    name
+}


### PR DESCRIPTION
Cleans up the model names in the landing screen model cards.
Some of the information is redundant to the user - `GGUF` and `Chat`. Removing the dashing makes it more readble.

## Note

### One downside to this is that the current search is not thorough enough to match "meta llama" to "Meta-LLaMa", so this change could be counter-productive. I thought it matches better the designs and it's cleaner for a demo, but feel free to ignore.

---
### Before
![Screenshot 2024-05-03 at 10 35 23 AM](https://github.com/project-robius/moxin/assets/22042418/42516601-c025-4925-9a2a-a375dfab239c)

### After
![Screenshot 2024-05-03 at 10 33 53 AM](https://github.com/project-robius/moxin/assets/22042418/c8c1b8f2-4e98-4263-a34b-8eb8de8df4b4)
