### PR TITLE
Progress and download controls for each model download item in the landing

### DIFF
--- a/moxin-frontend/src/app.rs
+++ b/moxin-frontend/src/app.rs
@@ -1,11 +1,10 @@
 use crate::chat::chat_panel::ChatPanelAction;
 use crate::data::store::*;
-use crate::landing::download_item::DownloadItemAction;
 use crate::landing::model_card::{ModelCardViewAllModalWidgetRefExt, ViewAllModalAction};
 use crate::landing::model_files_item::ModelFileItemAction;
 use crate::my_models::delete_model_modal::{DeleteModelAction, DeleteModelModalWidgetRefExt};
 use crate::my_models::model_info_modal::{ModelInfoAction, ModelInfoModalWidgetRefExt};
-use crate::shared::actions::ChatAction;
+use crate::shared::actions::{ChatAction, DownloadAction};
 use crate::shared::download_notification_popup::{
     DownloadNotificationPopupWidgetRefExt, DownloadResult, PopupAction,
 };
@@ -224,15 +223,15 @@ impl MatchEvent for App {
             }
 
             match action.as_widget_action().cast() {
-                DownloadItemAction::Play(file_id) => {
+                DownloadAction::Play(file_id) => {
                     self.store.download_file(file_id);
                     self.ui.redraw(cx);
                 }
-                DownloadItemAction::Pause(file_id) => {
+                DownloadAction::Pause(file_id) => {
                     self.store.pause_download_file(file_id);
                     self.ui.redraw(cx);
                 }
-                DownloadItemAction::Cancel(file_id) => {
+                DownloadAction::Cancel(file_id) => {
                     self.store.cancel_download_file(file_id);
                     self.ui.redraw(cx);
                 }
@@ -293,15 +292,17 @@ impl MatchEvent for App {
 impl App {
     fn notify_downloaded_files(&mut self, cx: &mut Cx) {
         if let Some(notification) = self.store.next_download_notification() {
-            let mut popup = self.ui.download_notification_popup(id!(popup_download_success));
+            let mut popup = self
+                .ui
+                .download_notification_popup(id!(popup_download_success));
 
             match notification {
                 DownloadPendingNotification::DownloadedFile(file) => {
                     popup.set_data(&file, DownloadResult::Success);
-                },
+                }
                 DownloadPendingNotification::DownloadErrored(file) => {
                     popup.set_data(&file, DownloadResult::Failure);
-                },
+                }
             }
 
             let mut modal = self.ui.modal(id!(modal_root));

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -182,15 +182,18 @@ impl Store {
         if let Some(result) = self.get_model_and_file_for_pending_download(file_id) {
             result
         } else {
-            self.get_model_and_file_from_search_results(file_id).unwrap()
+            self.get_model_and_file_from_search_results(file_id)
+                .unwrap()
         }
     }
 
     fn get_model_and_file_from_search_results(&self, file_id: &str) -> Option<(Model, File)> {
-        self.models
-            .iter()
-            .find_map(|m| m.files.iter().find(|f| f.id == file_id).map(|f| (m.clone(), f.clone()))
-        )
+        self.models.iter().find_map(|m| {
+            m.files
+                .iter()
+                .find(|f| f.id == file_id)
+                .map(|f| (m.clone(), f.clone()))
+        })
     }
 
     fn get_model_and_file_for_pending_download(&self, file_id: &str) -> Option<(Model, File)> {
@@ -557,22 +560,25 @@ impl Store {
     }
 
     pub fn next_download_notification(&mut self) -> Option<DownloadPendingNotification> {
-        self.current_downloads.iter_mut().filter_map(|(_, download)| {
-            if download.must_show_notification() {
-                if download.is_errored() {
-                    return Some(DownloadPendingNotification::DownloadErrored(
-                        download.file.clone(),
-                    ));
-                } else if download.is_complete() {
-                    return Some(DownloadPendingNotification::DownloadedFile(
-                        download.file.clone(),
-                    ));
-                } else {
-                    return None;
+        self.current_downloads
+            .iter_mut()
+            .filter_map(|(_, download)| {
+                if download.must_show_notification() {
+                    if download.is_errored() {
+                        return Some(DownloadPendingNotification::DownloadErrored(
+                            download.file.clone(),
+                        ));
+                    } else if download.is_complete() {
+                        return Some(DownloadPendingNotification::DownloadedFile(
+                            download.file.clone(),
+                        ));
+                    } else {
+                        return None;
+                    }
                 }
-            }
-            None
-        }).next()
+                None
+            })
+            .next()
     }
 
     // Utility functions

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -531,6 +531,10 @@ impl Store {
         let mut completed_download_ids = Vec::new();
 
         for (id, download) in &mut self.current_downloads {
+            if let Some(pending) = self.pending_downloads.iter_mut().find(|d| d.file.id == *id) {
+                pending.progress = download.get_progress();
+            }
+
             download.process_download_progress();
             if download.is_complete() {
                 completed_download_ids.push(id.clone());

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -544,7 +544,6 @@ impl Store {
             // Workaround to keep the duplicate data in pending downloads in sync.
             if let Some(pending) = self.pending_downloads.iter_mut().find(|d| d.file.id == *id) {
                 pending.progress = download.get_progress();
-                dbg!(download.state);
                 pending.status = match download.state {
                     DownloadState::Downloading(_) => PendingDownloadsStatus::Downloading,
                     DownloadState::Paused(_) => PendingDownloadsStatus::Paused,

--- a/moxin-frontend/src/data/store.rs
+++ b/moxin-frontend/src/data/store.rs
@@ -210,8 +210,13 @@ impl Store {
         let (model, file) = self.get_model_and_file_download(&file_id);
         let mut current_progress = 0.0;
 
-        if let Some(pending) = self.pending_downloads.iter().find(|d| d.file.id == file_id) {
+        if let Some(pending) = self
+            .pending_downloads
+            .iter_mut()
+            .find(|d| d.file.id == file_id)
+        {
             current_progress = pending.progress;
+            pending.status = PendingDownloadsStatus::Downloading;
         } else {
             let pending_download = PendingDownload {
                 file: file.clone(),
@@ -539,6 +544,7 @@ impl Store {
             // Workaround to keep the duplicate data in pending downloads in sync.
             if let Some(pending) = self.pending_downloads.iter_mut().find(|d| d.file.id == *id) {
                 pending.progress = download.get_progress();
+                dbg!(download.state);
                 pending.status = match download.state {
                     DownloadState::Downloading(_) => PendingDownloadsStatus::Downloading,
                     DownloadState::Paused(_) => PendingDownloadsStatus::Paused,

--- a/moxin-frontend/src/landing/download_item.rs
+++ b/moxin-frontend/src/landing/download_item.rs
@@ -1,6 +1,9 @@
 use crate::{
     data::{download::DownloadState, store::DownloadInfo},
-    shared::utils::{format_model_downloaded_size, format_model_size},
+    shared::{
+        actions::DownloadAction,
+        utils::{format_model_downloaded_size, format_model_size},
+    },
 };
 use makepad_widgets::*;
 use moxin_protocol::data::FileID;
@@ -201,14 +204,6 @@ live_design! {
     }
 }
 
-#[derive(Clone, DefaultNone, Debug)]
-pub enum DownloadItemAction {
-    Play(FileID),
-    Pause(FileID),
-    Cancel(FileID),
-    None,
-}
-
 #[derive(Live, LiveHook, Widget)]
 pub struct DownloadItem {
     #[deref]
@@ -306,12 +301,13 @@ impl Widget for DownloadItem {
                 self.button(id!(play_button)).set_visible(false);
                 self.button(id!(retry_button)).set_visible(true);
             }
-            DownloadState::Completed => ()
+            DownloadState::Completed => (),
         }
 
         let total_size = format_model_size(&download.file.size).unwrap_or("-".to_string());
-        let downloaded_size = format_model_downloaded_size(&download.file.size, download.get_progress())
-            .unwrap_or("-".to_string());
+        let downloaded_size =
+            format_model_downloaded_size(&download.file.size, download.get_progress())
+                .unwrap_or("-".to_string());
 
         self.label(id!(downloaded_size))
             .set_text(&format!("{} / {}", downloaded_size, total_size));
@@ -329,7 +325,7 @@ impl WidgetMatchEvent for DownloadItem {
                 cx.widget_action(
                     widget_uid,
                     &scope.path,
-                    DownloadItemAction::Play(file_id.clone()),
+                    DownloadAction::Play(file_id.clone()),
                 )
             }
         }
@@ -340,7 +336,7 @@ impl WidgetMatchEvent for DownloadItem {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadItemAction::Pause(file_id.clone()),
+                DownloadAction::Pause(file_id.clone()),
             )
         }
 
@@ -350,7 +346,7 @@ impl WidgetMatchEvent for DownloadItem {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadItemAction::Cancel(file_id.clone()),
+                DownloadAction::Cancel(file_id.clone()),
             )
         }
     }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -17,6 +17,11 @@ live_design! {
     START_CHAT = dep("crate://self/resources/icons/start_chat.svg")
     RESUME_CHAT = dep("crate://self/resources/icons/play_arrow.svg")
 
+    ICON_PAUSE = dep("crate://self/resources/icons/pause_download.svg")
+    ICON_CANCEL = dep("crate://self/resources/icons/cancel_download.svg")
+    ICON_PLAY = dep("crate://self/resources/icons/play_download.svg")
+    ICON_RETRY = dep("crate://self/resources/icons/retry_download.svg")
+
     ModelFilesRow = <RoundedYView> {
         width: Fill,
         height: Fit,
@@ -69,13 +74,69 @@ live_design! {
         }
     }
 
-    DownloadPendingButton = <ModelCardButton> {
-        draw_bg: { color: #fff, border_color: #x155EEF, border_width: 0.5}
-        text: "Downloading..."
-        enabled: false
+    // TODO This is a very temporary solution, we will have a better way to handle this.
+    DownloadPendingButton = <View> {
+        align: {y: 0.5},
+        spacing: 8,
+        progress_bar = <View> {
+            width: 74,
+            height: 12,
+            flow: Overlay,
 
-        draw_text: {
-            color: #x155EEF;
+            <RoundedView> {
+                height: Fill,
+                draw_bg: {
+                    color: #D9D9D9,
+                    radius: 2.5,
+                }
+            }
+
+            progress_fill = <RoundedView> {
+                width: 0,
+                height: Fill,
+                draw_bg: {
+                    color: #099250,
+                    radius: 2.5,
+                }
+            }
+        }
+        progress_text = <Label> {
+            text: "0%",
+            draw_text: {
+                text_style: <BOLD_FONT>{font_size: 9},
+                color: #087443
+            }
+        }
+        resume_button = <Button> {
+            padding: 4,
+            draw_icon: {
+                fn get_color(self) -> vec4 {
+                    return #667085;
+                }
+                svg_file: (ICON_PLAY),
+            }
+            icon_walk: {width: 14, height: 14}
+        }
+        /*pause_button = <Button> {
+            visible: false,
+            padding: 4,
+            draw_icon: {
+                fn get_color(self) -> vec4 {
+                    return #667085;
+                }
+                svg_file: (ICON_PAUSE),
+            }
+            icon_walk: {width: 14, height: 14}
+        }*/
+        cancel_button = <Button> {
+            padding: 4,
+            draw_icon: {
+                fn get_color(self) -> vec4 {
+                    return #667085;
+                }
+                svg_file: (ICON_CANCEL),
+            }
+            icon_walk: {width: 14, height: 14}
         }
     }
 
@@ -129,7 +190,6 @@ live_design! {
         }
 
         cell4 = {
-            align: {x: 0.5, y: 0.5},
             download_button = <DownloadButton> { visible: false }
             start_chat_button = <StartChatButton> { visible: false }
             resume_chat_button = <ResumeChatButton> { visible: false }
@@ -167,7 +227,9 @@ impl Widget for ModelFilesItem {
 impl WidgetMatchEvent for ModelFilesItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let widget_uid = self.widget_uid();
-        let Some(file_id) = self.file_id.clone() else { return; };
+        let Some(file_id) = self.file_id.clone() else {
+            return;
+        };
 
         if self.button(id!(download_button)).clicked(&actions) {
             cx.widget_action(
@@ -178,19 +240,11 @@ impl WidgetMatchEvent for ModelFilesItem {
         }
 
         if self.button(id!(start_chat_button)).clicked(&actions) {
-            cx.widget_action(
-                widget_uid,
-                &scope.path,
-                ChatAction::Start(file_id.clone()),
-            );
+            cx.widget_action(widget_uid, &scope.path, ChatAction::Start(file_id.clone()));
         }
 
         if self.button(id!(resume_chat_button)).clicked(&actions) {
-            cx.widget_action(
-                widget_uid,
-                &scope.path,
-                ChatAction::Resume(file_id),
-            );
+            cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id));
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -110,7 +110,7 @@ live_design! {
                 color: #087443
             }
         }
-        resume_button = <Button> {
+        resume_download_button = <Button> {
             padding: 4,
             draw_icon: {
                 fn get_color(self) -> vec4 {
@@ -120,8 +120,7 @@ live_design! {
             }
             icon_walk: {width: 14, height: 14}
         }
-        pause_button = <Button> {
-            // visible: false,
+        pause_download_button = <Button> {
             padding: 4,
             draw_icon: {
                 fn get_color(self) -> vec4 {
@@ -131,7 +130,7 @@ live_design! {
             }
             icon_walk: {width: 14, height: 14}
         }
-        cancel_button = <Button> {
+        cancel_download_button = <Button> {
             padding: 4,
             draw_icon: {
                 fn get_color(self) -> vec4 {
@@ -250,7 +249,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id));
         }
 
-        if self.button(id!(resume_button)).clicked(&actions) {
+        if self.button(id!(resume_download_button)).clicked(&actions) {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
@@ -258,7 +257,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             );
         }
 
-        if self.button(id!(pause_button)).clicked(&actions) {
+        if self.button(id!(pause_download_button)).clicked(&actions) {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
@@ -266,7 +265,7 @@ impl WidgetMatchEvent for ModelFilesItem {
             );
         }
 
-        if self.button(id!(cancel_button)).clicked(&actions) {
+        if self.button(id!(cancel_download_button)).clicked(&actions) {
             cx.widget_action(
                 widget_uid,
                 &scope.path,

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -77,6 +77,16 @@ live_design! {
         }
     }
 
+    DownloadPendingButton = <Button> {
+        padding: 4,
+        draw_icon: {
+            fn get_color(self) -> vec4 {
+                return #667085;
+            }
+        }
+        icon_walk: {width: 14, height: 14}
+    }
+
     DownloadPendingControls = <View> {
         align: {y: 0.5},
         spacing: 8,
@@ -109,35 +119,20 @@ live_design! {
                 color: #087443
             }
         }
-        resume_download_button = <Button> {
-            padding: 4,
+        resume_download_button = <DownloadPendingButton> {
             draw_icon: {
-                fn get_color(self) -> vec4 {
-                    return #667085;
-                }
                 svg_file: (ICON_PLAY),
             }
-            icon_walk: {width: 14, height: 14}
         }
-        pause_download_button = <Button> {
-            padding: 4,
+        pause_download_button = <DownloadPendingButton> {
             draw_icon: {
-                fn get_color(self) -> vec4 {
-                    return #667085;
-                }
                 svg_file: (ICON_PAUSE),
             }
-            icon_walk: {width: 14, height: 14}
         }
-        cancel_download_button = <Button> {
-            padding: 4,
+        cancel_download_button = <DownloadPendingButton> {
             draw_icon: {
-                fn get_color(self) -> vec4 {
-                    return #667085;
-                }
                 svg_file: (ICON_CANCEL),
             }
-            icon_walk: {width: 14, height: 14}
         }
     }
 

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -77,8 +77,7 @@ live_design! {
         }
     }
 
-    // TODO This is a very temporary solution, we will have a better way to handle this.
-    DownloadPendingButton = <View> {
+    DownloadPendingControls = <View> {
         align: {y: 0.5},
         spacing: 8,
         progress_bar = <View> {
@@ -195,7 +194,7 @@ live_design! {
             download_button = <DownloadButton> { visible: false }
             start_chat_button = <StartChatButton> { visible: false }
             resume_chat_button = <ResumeChatButton> { visible: false }
-            download_pending_button = <DownloadPendingButton> { visible: false }
+            download_pending_controls = <DownloadPendingControls> { visible: false }
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -106,12 +106,17 @@ live_design! {
                 }
             }
         }
-        progress_text = <Label> {
-            text: "0%",
-            draw_text: {
-                text_style: <BOLD_FONT>{font_size: 9},
+        progress_text_layout = <View> {
+            width: 40,
+            align: {x: 1, y: 0.5},
+            progress_text = <Label> {
+                text: "0%",
+                draw_text: {
+                    text_style: <BOLD_FONT>{font_size: 9},
+                }
             }
         }
+
         resume_download_button = <DownloadPendingButton> {
             draw_icon: {
                 svg_file: (ICON_PLAY),

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -75,6 +75,9 @@ live_design! {
     }
 
     DownloadPendingButton = <MoxinButton> {
+        width: 25,
+        height: 25,
+        padding: 4,
         draw_icon: {
             fn get_color(self) -> vec4 {
                 return #667085;
@@ -118,6 +121,7 @@ live_design! {
         }
 
         resume_download_button = <DownloadPendingButton> {
+            icon_walk: { margin: { left: 4 } }
             draw_icon: {
                 svg_file: (ICON_PLAY),
             }
@@ -128,6 +132,7 @@ live_design! {
             }
         }
         pause_download_button = <DownloadPendingButton> {
+            icon_walk: { margin: { left: 4 } }
             draw_icon: {
                 svg_file: (ICON_PAUSE),
             }

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -102,7 +102,6 @@ live_design! {
                 width: 0,
                 height: Fill,
                 draw_bg: {
-                    color: #099250,
                     radius: 2.5,
                 }
             }
@@ -111,12 +110,16 @@ live_design! {
             text: "0%",
             draw_text: {
                 text_style: <BOLD_FONT>{font_size: 9},
-                color: #087443
             }
         }
         resume_download_button = <DownloadPendingButton> {
             draw_icon: {
                 svg_file: (ICON_PLAY),
+            }
+        }
+        retry_download_button = <DownloadPendingButton> {
+            draw_icon: {
+                svg_file: (ICON_RETRY),
             }
         }
         pause_download_button = <DownloadPendingButton> {
@@ -238,7 +241,10 @@ impl WidgetMatchEvent for ModelFilesItem {
             cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id.clone()));
         }
 
-        if self.button(id!(resume_download_button)).clicked(&actions) {
+        if [id!(resume_download_button), id!(retry_download_button)]
+            .iter()
+            .any(|id| self.button(*id).clicked(&actions))
+        {
             cx.widget_action(
                 widget_uid,
                 &scope.path,

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -2,10 +2,7 @@ use makepad_widgets::*;
 use moxin_protocol::data::{File, FileID};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
-use crate::shared::{
-    actions::{ChatAction, DownloadAction},
-    widgets::c_button::CButtonWidgetExt,
-};
+use crate::shared::actions::{ChatAction, DownloadAction};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -240,7 +237,7 @@ impl WidgetMatchEvent for ModelFilesItem {
         }
 
         if self.button(id!(resume_chat_button)).clicked(&actions) {
-            cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id));
+            cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id.clone()));
         }
 
         if self.button(id!(resume_download_button)).clicked(&actions) {

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -120,8 +120,8 @@ live_design! {
             }
             icon_walk: {width: 14, height: 14}
         }
-        /*pause_button = <Button> {
-            visible: false,
+        pause_button = <Button> {
+            // visible: false,
             padding: 4,
             draw_icon: {
                 fn get_color(self) -> vec4 {
@@ -130,7 +130,7 @@ live_design! {
                 svg_file: (ICON_PAUSE),
             }
             icon_walk: {width: 14, height: 14}
-        }*/
+        }
         cancel_button = <Button> {
             padding: 4,
             draw_icon: {

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -74,14 +74,12 @@ live_design! {
         }
     }
 
-    DownloadPendingButton = <Button> {
-        padding: 4,
+    DownloadPendingButton = <MoxinButton> {
         draw_icon: {
             fn get_color(self) -> vec4 {
                 return #667085;
             }
         }
-        icon_walk: {width: 14, height: 14}
     }
 
     DownloadPendingControls = <View> {

--- a/moxin-frontend/src/landing/model_files_item.rs
+++ b/moxin-frontend/src/landing/model_files_item.rs
@@ -2,7 +2,10 @@ use makepad_widgets::*;
 use moxin_protocol::data::{File, FileID};
 
 use super::model_files_tags::ModelFilesTagsWidgetExt;
-use crate::shared::{actions::ChatAction, widgets::c_button::CButtonWidgetExt};
+use crate::shared::{
+    actions::{ChatAction, DownloadAction},
+    widgets::c_button::CButtonWidgetExt,
+};
 
 live_design! {
     import makepad_widgets::base::*;
@@ -245,6 +248,30 @@ impl WidgetMatchEvent for ModelFilesItem {
 
         if self.button(id!(resume_chat_button)).clicked(&actions) {
             cx.widget_action(widget_uid, &scope.path, ChatAction::Resume(file_id));
+        }
+
+        if self.button(id!(resume_button)).clicked(&actions) {
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadAction::Play(file_id.clone()),
+            );
+        }
+
+        if self.button(id!(pause_button)).clicked(&actions) {
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadAction::Pause(file_id.clone()),
+            );
+        }
+
+        if self.button(id!(cancel_button)).clicked(&actions) {
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                DownloadAction::Cancel(file_id.clone()),
+            );
         }
     }
 }

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -3,7 +3,7 @@ use crate::{
     shared::utils::format_model_size,
 };
 use makepad_widgets::*;
-use moxin_protocol::data::{File, FileID, Model, PendingDownload};
+use moxin_protocol::data::{File, FileID, PendingDownload};
 
 use super::model_files_item::ModelFilesItemWidgetRefExt;
 
@@ -104,7 +104,9 @@ impl ModelFilesList {
                 .items
                 .get_or_insert(cx, item_id, |cx| WidgetRef::new_from_ptr(cx, self.template));
 
-            item_widget.as_model_files_item().set_file(cx, files[i].clone());
+            item_widget
+                .as_model_files_item()
+                .set_file(cx, files[i].clone());
 
             let filename = &files[i].name;
             let size = format_model_size(&files[i].size).unwrap_or("-".to_string());
@@ -122,15 +124,25 @@ impl ModelFilesList {
                 },
             );
 
-            if pending_downloads
-                .iter()
-                .find(|f| f.file.id == files[i].id)
-                .is_some()
-            {
+            if let Some(download) = pending_downloads.iter().find(|f| f.file.id == files[i].id) {
+                let progress = format!("{:.1}%", download.progress);
+                let progress_fill_max = 74.0;
+                let progress_fill = download.progress * progress_fill_max / 100.0;
+
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button = { visible: true }
+                        download_pending_button = {
+                            visible: true
+                            progress_text = {
+                                text: (progress)
+                            }
+                            progress_bar = {
+                                progress_fill = {
+                                    width: (progress_fill)
+                                }
+                            }
+                        }
                         start_chat_button = { visible: false }
                         resume_chat_button = { visible: false }
                         download_button = { visible: false }

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -3,7 +3,7 @@ use crate::{
     shared::utils::format_model_size,
 };
 use makepad_widgets::*;
-use moxin_protocol::data::{File, FileID, PendingDownload};
+use moxin_protocol::data::{File, FileID, PendingDownload, PendingDownloadsStatus};
 
 use super::model_files_item::ModelFilesItemWidgetRefExt;
 
@@ -129,6 +129,11 @@ impl ModelFilesList {
                 let progress_fill_max = 74.0;
                 let progress_fill = download.progress * progress_fill_max / 100.0;
 
+                let is_resume_download_visible =
+                    matches!(download.status, PendingDownloadsStatus::Paused);
+                let is_pause_download_visible =
+                    matches!(download.status, PendingDownloadsStatus::Downloading);
+
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
@@ -141,6 +146,12 @@ impl ModelFilesList {
                                 progress_fill = {
                                     width: (progress_fill)
                                 }
+                            }
+                            resume_download_button = {
+                                visible: (is_resume_download_visible)
+                            }
+                            pause_download_button = {
+                                visible: (is_pause_download_visible)
                             }
                         }
                         start_chat_button = { visible: false }

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -137,7 +137,7 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button = {
+                        download_pending_controls = {
                             visible: true
                             progress_text = {
                                 text: (progress)
@@ -167,7 +167,7 @@ impl ModelFilesList {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button = { visible: false }
+                            download_pending_controls = { visible: false }
                             start_chat_button = { visible: false }
                             resume_chat_button = { visible: true }
                             download_button = { visible: false }
@@ -177,7 +177,7 @@ impl ModelFilesList {
                     item_widget.apply_over(
                         cx,
                         live! { cell4 = {
-                            download_pending_button = { visible: false }
+                            download_pending_controls = { visible: false }
                             start_chat_button = { visible: true }
                             resume_chat_button = { visible: false }
                             download_button = { visible: false }
@@ -188,7 +188,7 @@ impl ModelFilesList {
                 item_widget.apply_over(
                     cx,
                     live! { cell4 = {
-                        download_pending_button = { visible: false }
+                        download_pending_controls = { visible: false }
                         start_chat_button = { visible: false }
                         resume_chat_button = { visible: false }
                         download_button = { visible: true }

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -133,6 +133,14 @@ impl ModelFilesList {
                     matches!(download.status, PendingDownloadsStatus::Paused);
                 let is_pause_download_visible =
                     matches!(download.status, PendingDownloadsStatus::Downloading);
+                let is_retry_download_visible =
+                    matches!(download.status, PendingDownloadsStatus::Error);
+
+                let status_color = match download.status {
+                    PendingDownloadsStatus::Downloading => vec3(0.035, 0.572, 0.314), // #099250
+                    PendingDownloadsStatus::Paused => vec3(0.4, 0.44, 0.52),          // #667085
+                    PendingDownloadsStatus::Error => vec3(0.7, 0.11, 0.09),           // #B42318
+                };
 
                 item_widget.apply_over(
                     cx,
@@ -141,14 +149,23 @@ impl ModelFilesList {
                             visible: true
                             progress_text = {
                                 text: (progress)
+                                draw_text: {
+                                    color: (status_color)
+                                }
                             }
                             progress_bar = {
                                 progress_fill = {
                                     width: (progress_fill)
+                                    draw_bg: {
+                                        color: (status_color),
+                                    }
                                 }
                             }
                             resume_download_button = {
                                 visible: (is_resume_download_visible)
+                            }
+                            retry_download_button = {
+                                visible: (is_retry_download_visible)
                             }
                             pause_download_button = {
                                 visible: (is_pause_download_visible)

--- a/moxin-frontend/src/landing/model_files_list.rs
+++ b/moxin-frontend/src/landing/model_files_list.rs
@@ -147,10 +147,12 @@ impl ModelFilesList {
                     live! { cell4 = {
                         download_pending_controls = {
                             visible: true
-                            progress_text = {
-                                text: (progress)
-                                draw_text: {
-                                    color: (status_color)
+                            progress_text_layout = {
+                                progress_text = {
+                                    text: (progress)
+                                    draw_text: {
+                                        color: (status_color)
+                                    }
                                 }
                             }
                             progress_bar = {

--- a/moxin-frontend/src/shared/actions.rs
+++ b/moxin-frontend/src/shared/actions.rs
@@ -7,3 +7,11 @@ pub enum ChatAction {
     Resume(FileID),
     None,
 }
+
+#[derive(Clone, DefaultNone, Debug)]
+pub enum DownloadAction {
+    Play(FileID),
+    Pause(FileID),
+    Cancel(FileID),
+    None,
+}

--- a/moxin-frontend/src/shared/download_notification_popup.rs
+++ b/moxin-frontend/src/shared/download_notification_popup.rs
@@ -1,7 +1,7 @@
 use makepad_widgets::*;
 use moxin_protocol::data::{File, FileID};
 
-use crate::landing::download_item::DownloadItemAction;
+use crate::shared::actions::DownloadAction;
 
 use super::modal::ModalAction;
 
@@ -247,18 +247,21 @@ impl WidgetMatchEvent for DownloadNotificationPopup {
             }
         }
 
-        if self.link_label(id!(view_in_my_models_link)).clicked(actions) {
+        if self
+            .link_label(id!(view_in_my_models_link))
+            .clicked(actions)
+        {
             // TODO: Abstract the navigation actions on a single enum for the whole app.
             cx.widget_action(widget_uid, &scope.path, PopupAction::NavigateToMyModels);
             cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
         }
-        
+
         if self.link_label(id!(retry_link)).clicked(actions) {
             let Some(file_id) = &self.file_id else { return };
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadItemAction::Play(file_id.clone()),
+                DownloadAction::Play(file_id.clone()),
             );
             cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
         }
@@ -268,7 +271,7 @@ impl WidgetMatchEvent for DownloadNotificationPopup {
             cx.widget_action(
                 widget_uid,
                 &scope.path,
-                DownloadItemAction::Cancel(file_id.clone()),
+                DownloadAction::Cancel(file_id.clone()),
             );
             cx.widget_action(widget_uid, &scope.path, ModalAction::CloseModal);
         }
@@ -279,7 +282,7 @@ impl DownloadNotificationPopup {
     pub fn update_content(&mut self) {
         match self.download_result {
             DownloadResult::Success => self.show_success_content(),
-            DownloadResult::Failure => self.show_failure_content()
+            DownloadResult::Failure => self.show_failure_content(),
         }
     }
 
@@ -307,8 +310,12 @@ impl DownloadNotificationPopup {
         self.label(id!(title))
             .set_text("Errors while downloading models");
 
-        self.label(id!(summary))
-            .set_text(&(format!("{} encountered some errors when downloading.", &self.filename)));
+        self.label(id!(summary)).set_text(
+            &(format!(
+                "{} encountered some errors when downloading.",
+                &self.filename
+            )),
+        );
     }
 }
 


### PR DESCRIPTION
# Changes
- See download progress of each model file with a progress bar and text.
- Resume, pause, cancel and retry controls inline with the progress.

# Links
- [Figma](https://www.figma.com/design/LIaqW5HF3CGtq4XMpDxDMD/MoxinUI---LLM-Desktop-App?node-id=1332-17276&t=QvBkQt8twguLLYZh-0)

# Notes
- Although not in the design, the decimal precision has been added to the text progress because:
  - It's consistent with what we already have.
  - Without it, it's difficult to tell quickly if everything is working properly.
- Because of the previous point, the buttons may be placed a bit more on the right than in the design.

# Screenshots

![image](https://github.com/moxin-org/moxin/assets/7684329/5dbe5f02-7c2b-4c2e-bd76-2ad5fa2aa3e5)

