### PR TITLE
Fix minor issue with separators in My Models listing

### DIFF
--- a/moxin-frontend/src/my_models/downloaded_files_row.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_row.rs
@@ -184,7 +184,6 @@ live_design! {
 
 pub struct DownloadedFilesRowProps {
     pub downloaded_file: DownloadedFile,
-    pub show_separator: bool,
     pub show_resume: bool,
 }
 
@@ -248,8 +247,6 @@ impl Widget for DownloadedFilesRow {
 
         self.button(id!(start_chat_button)).set_visible(!props.show_resume);
         self.button(id!(resume_chat_button)).set_visible(props.show_resume);
-
-        self.view(id!(separator_line)).set_visible(props.show_separator);
 
         self.view.draw_walk(cx, scope, walk)
     }

--- a/moxin-frontend/src/my_models/downloaded_files_table.rs
+++ b/moxin-frontend/src/my_models/downloaded_files_table.rs
@@ -138,7 +138,6 @@ impl Widget for DownloadedFilesTable {
 
                         let props = DownloadedFilesRowProps {
                             downloaded_file: file_data.clone(),
-                            show_separator: item_id != last_item_id,
                             show_resume: is_model_file_loaded,
                         };
                         let mut scope = Scope::with_props(&props);


### PR DESCRIPTION
There were a need to differentiate the first row in this listing in previous versions of the design, but it doesn't seem to be needed in the latest version.

Before:

<img width="1246" alt="image" src="https://github.com/moxin-org/moxin/assets/487140/ca4abe93-2d9e-4848-8e50-f1a8f5694f7d">


After:

<img width="1254" alt="image" src="https://github.com/moxin-org/moxin/assets/487140/5091f195-24b6-4026-ba60-d77add0d7203">
 