### PR TITLE
Make Moxin runnable from a macOS `.app` bundle.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 name = "moxin"
 version = "0.1.0"
 edition = "2021"
-description = "A Client for Downloading and Chatting with AI LLMs"
+description = "A desktop GUI client for downloading and chatting with AI LLMs"
 
 [dependencies]
 moxin-protocol = { path = "moxin-protocol" }
@@ -33,3 +33,11 @@ rand = "0.8.5"
 
 [package.metadata.bundle]
 identifier = "com.moxin-org.moxin"
+long_description = """
+Moxin is a desktop GUI client that lets you browse AI Large Language Models (LLMs), download them,
+and run them locally to chat with the models.
+Moxin is built using the Makepad UI framework (https://github.com/makepad/makepad)
+and Project Robius platform abstractions (https://github.com/project-robius),
+and currently runs on all three major desktop platforms: Windows, macOS, and Linux.
+Moxin uses the wasmedge WASM runtime to locally run the AI models.
+"""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 name = "moxin"
 version = "0.1.0"
 edition = "2021"
+description = "A Client for Downloading and Chatting with AI LLMs"
 
 [dependencies]
 moxin-protocol = { path = "moxin-protocol" }
@@ -28,3 +29,7 @@ serde_json = "1.0"
 serde = { version = "1.0.197", features = ["derive"] }
 lipsum = "0.9"
 rand = "0.8.5"
+
+
+[package.metadata.bundle]
+identifier = "com.moxin-org.moxin"

--- a/moxin-backend/src/backend_impls.rs
+++ b/moxin-backend/src/backend_impls.rs
@@ -853,8 +853,6 @@ impl BackendImpl {
     ) -> Sender<Command> {
         wasmedge_sdk::plugin::PluginManager::load(None).unwrap();
 
-        eprintln!("KEVIN: cwd: {:?}, exe: {:?}, home_dir: {home_dir}, models_dir: {models_dir}", std::env::current_dir(), std::env::current_exe());
-        eprintln!("KEVIN: env vars: {:#?}", std::env::vars().into_iter().collect::<Vec<_>>());
         let sql_conn = rusqlite::Connection::open(format!("{home_dir}/data.sqlite")).unwrap();
 
         // TODO Reorganize these bunch of functions, needs a little more of thought

--- a/moxin-backend/src/backend_impls.rs
+++ b/moxin-backend/src/backend_impls.rs
@@ -853,6 +853,8 @@ impl BackendImpl {
     ) -> Sender<Command> {
         wasmedge_sdk::plugin::PluginManager::load(None).unwrap();
 
+        eprintln!("KEVIN: cwd: {:?}, exe: {:?}, home_dir: {home_dir}, models_dir: {models_dir}", std::env::current_dir(), std::env::current_exe());
+        eprintln!("KEVIN: env vars: {:#?}", std::env::vars().into_iter().collect::<Vec<_>>());
         let sql_conn = rusqlite::Connection::open(format!("{home_dir}/data.sqlite")).unwrap();
 
         // TODO Reorganize these bunch of functions, needs a little more of thought

--- a/moxin-backend/src/lib.rs
+++ b/moxin-backend/src/lib.rs
@@ -10,10 +10,12 @@ pub struct Backend {
 
 impl Default for Backend {
     fn default() -> Self {
-        // Backend::new(".".to_string(), ".".to_string(), 3)
-        // KEVIN
-        let home = std::env::var("HOME").expect("HOME env var was not set");
-        Backend::new(home.clone(), home, 3)
+        // TODO: FIXME: use directories::ProjectDirs::data_dir() instead.
+        // <https://docs.rs/directories/latest/directories/struct.ProjectDirs.html#method.data_dir>
+        let home_dir = std::env::var("HOME") // Unix-like systems
+            .or_else(|_| std::env::var("USERPROFILE")) // Windows
+            .unwrap_or_else(|_| ".".to_string());
+        Backend::new(home_dir.clone(), home_dir, 3)
     }
 }
 

--- a/moxin-backend/src/lib.rs
+++ b/moxin-backend/src/lib.rs
@@ -10,7 +10,10 @@ pub struct Backend {
 
 impl Default for Backend {
     fn default() -> Self {
-        Backend::new(".".to_string(), ".".to_string(), 3)
+        // Backend::new(".".to_string(), ".".to_string(), 3)
+        // KEVIN
+        let home = std::env::var("HOME").expect("HOME env var was not set");
+        Backend::new(home.clone(), home, 3)
     }
 }
 

--- a/src/data/filesystem.rs
+++ b/src/data/filesystem.rs
@@ -22,8 +22,8 @@ pub fn setup_model_downloads_folder() -> String {
 }
 
 fn home_dir() -> String {
-    env::var("HOME"). // Unix-like systems
-        or_else(|_| env::var("USERPROFILE")) // Windows
+    env::var("HOME") // Unix-like systems
+        .or_else(|_| env::var("USERPROFILE")) // Windows
         .unwrap_or_else(|_| ".".to_string())
 }
 

--- a/src/data/filesystem.rs
+++ b/src/data/filesystem.rs
@@ -22,6 +22,8 @@ pub fn setup_model_downloads_folder() -> String {
 }
 
 fn home_dir() -> String {
+    // TODO: FIXME: use directories::ProjectDirs::data_dir() instead.
+    // <https://docs.rs/directories/latest/directories/struct.ProjectDirs.html#method.data_dir>
     env::var("HOME") // Unix-like systems
         .or_else(|_| env::var("USERPROFILE")) // Windows
         .unwrap_or_else(|_| ".".to_string())


### PR DESCRIPTION
~~**Note: do not merge this yet, it's messy.**~~ ready now

The problem is that when an app bundle is run, the current working directory is `/` (root), which is read-only on macOS. Thus, the attempt to access `./data.sqlite` is actually an attempt to create the file `/data.sqlite`, which immediately fails because a file cannot be created on the read-only root partition.

Instead of using the current working directory, this commit now changes file paths to be relative to `$HOME`, which will only really work properly on Unix-like environments where the `$HOME` environment variable is defined. Even on Unix-like systems, this isn't *guaranteed* to work, since various sandboxing or environment masking techniques may be in effect.

To actually create the bundle:
1. install cargo-bundle: `cargo install cargo-bundle`
2. run `cargo bundle` in the moxin repo directory.
3. patch the bundled moxin binary to depend directly on the installed wasmedge dylib:
    ```sh
    install_name_tool -change "@rpath/libwasmedge.0.dylib"  "$HOME/.wasmedge/lib/libwasmedge.0.dylib"  target/debug/bundle/osx/moxin.app/Contents/MacOS/moxin
    ```
    * Note that if you build in release mode with `cargo bundle --release`, the path will be `target/release/bundle...`.
    * This also assumes that you have installed wasmedge properly, which can be done via:
       ```sh
       curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash
       source $HOME/.wasmedge/env
       ```
4. Now you can run the `moxin.app` bundle (located in `moxin/target/debug/bundle/osx/` by double-clicking it in Finder, or by running `open moxin.app`.

