### PR TITLE
fix - chat panel visibility states + refactor - local state reconciliation

### DIFF
--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -508,60 +508,9 @@ impl Widget for ChatPanel {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        self.switch_visibilities(cx, scope);
+
         let store = scope.data.get_mut::<Store>().unwrap();
-
-        #[derive(Debug)]
-        enum State {
-            NoModelsAvailable,
-            NoModelSelected,
-            ModelSelectedWithEmptyChat,
-            ModelSelectedWithChat,
-        }
-
-        let state = if store.downloads.downloaded_files.is_empty() {
-            State::NoModelsAvailable
-        } else if store.chats.loaded_model.is_none() {
-            State::NoModelSelected
-        } else {
-            store
-                .chats
-                .get_current_chat()
-                .map_or(State::ModelSelectedWithEmptyChat, |chat| {
-                    if chat.borrow().messages.is_empty() {
-                        State::ModelSelectedWithEmptyChat
-                    } else {
-                        State::ModelSelectedWithChat
-                    }
-                })
-        };
-
-        dbg!(&state);
-
-        match state {
-            State::NoModelsAvailable => {
-                self.view(id!(no_downloaded_model)).set_visible(true);
-                self.view(id!(no_model)).set_visible(false);
-                //self.view(id!(main)).set_visible(false);
-                self.view(id!(empty_conversation)).set_visible(false);
-            }
-            State::NoModelSelected => {
-                self.view(id!(no_downloaded_model)).set_visible(false);
-                self.view(id!(no_model)).set_visible(true);
-                //self.view(id!(main)).set_visible(false);
-                self.view(id!(empty_conversation)).set_visible(false);
-            }
-            State::ModelSelectedWithEmptyChat => {
-                self.view(id!(no_downloaded_model)).set_visible(false);
-                self.view(id!(no_model)).set_visible(false);
-                //self.view(id!(main)).set_visible(true);
-                self.view(id!(empty_conversation)).set_visible(true);
-            }
-            State::ModelSelectedWithChat => {
-                self.view(id!(no_downloaded_model)).set_visible(false);
-                self.view(id!(no_model)).set_visible(false);
-                self.view(id!(empty_conversation)).set_visible(false);
-            }
-        }
 
         // TODO: Rename "chat_history", "chat_count", etc, they are messages of a chat
         // can be confused with the actual Chat type.
@@ -981,6 +930,60 @@ impl ChatPanel {
             auto_scroll_pending: true,
             auto_scroll_cancellable: false,
         };
+    }
+
+    fn switch_visibilities(&mut self, cx: &mut Cx2d, scope: &mut Scope) {
+        let store = scope.data.get_mut::<Store>().unwrap();
+
+        enum State {
+            NoModelsAvailable,
+            NoModelSelected,
+            ModelSelectedWithEmptyChat,
+            ModelSelectedWithChat,
+        }
+
+        let state = if store.downloads.downloaded_files.is_empty() {
+            State::NoModelsAvailable
+        } else if store.chats.loaded_model.is_none() {
+            State::NoModelSelected
+        } else {
+            store
+                .chats
+                .get_current_chat()
+                .map_or(State::ModelSelectedWithEmptyChat, |chat| {
+                    if chat.borrow().messages.is_empty() {
+                        State::ModelSelectedWithEmptyChat
+                    } else {
+                        State::ModelSelectedWithChat
+                    }
+                })
+        };
+
+        match state {
+            State::NoModelsAvailable => {
+                self.view(id!(no_downloaded_model)).set_visible(true);
+                self.view(id!(no_model)).set_visible(false);
+                //self.view(id!(main)).set_visible(false);
+                self.view(id!(empty_conversation)).set_visible(false);
+            }
+            State::NoModelSelected => {
+                self.view(id!(no_downloaded_model)).set_visible(false);
+                self.view(id!(no_model)).set_visible(true);
+                //self.view(id!(main)).set_visible(false);
+                self.view(id!(empty_conversation)).set_visible(false);
+            }
+            State::ModelSelectedWithEmptyChat => {
+                self.view(id!(no_downloaded_model)).set_visible(false);
+                self.view(id!(no_model)).set_visible(false);
+                //self.view(id!(main)).set_visible(true);
+                self.view(id!(empty_conversation)).set_visible(true);
+            }
+            State::ModelSelectedWithChat => {
+                self.view(id!(no_downloaded_model)).set_visible(false);
+                self.view(id!(no_model)).set_visible(false);
+                self.view(id!(empty_conversation)).set_visible(false);
+            }
+        }
     }
 }
 

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -868,18 +868,6 @@ impl ChatPanel {
     }
 
     fn update_visibilities(&mut self, scope: &mut Scope) {
-        macro_rules! show {
-            ($view_id:ident) => {
-                self.view(id!($view_id)).set_visible(true)
-            };
-        }
-
-        macro_rules! hide {
-            ($view_id:ident) => {
-                self.view(id!($view_id)).set_visible(false)
-            };
-        }
-
         let store = scope.data.get_mut::<Store>().unwrap();
 
         enum ComputedState {
@@ -906,42 +894,48 @@ impl ChatPanel {
             )
         };
 
+        let empty_conversation = self.view(id!(empty_conversation));
+        let jump_to_bottom = self.view(id!(jump_to_bottom));
+        let main = self.view(id!(main));
+        let no_downloaded_model = self.view(id!(no_downloaded_model));
+        let no_model = self.view(id!(no_model));
+
         match state {
             ComputedState::NoModelsAvailable => {
-                hide!(empty_conversation);
-                hide!(jump_to_bottom);
-                hide!(main);
-                hide!(no_model);
+                empty_conversation.set_visible(false);
+                jump_to_bottom.set_visible(false);
+                main.set_visible(false);
+                no_model.set_visible(false);
 
-                show!(no_downloaded_model);
+                no_downloaded_model.set_visible(true);
             }
             ComputedState::NoModelSelected => {
-                hide!(empty_conversation);
-                hide!(jump_to_bottom);
-                hide!(main);
-                hide!(no_downloaded_model);
+                empty_conversation.set_visible(false);
+                jump_to_bottom.set_visible(false);
+                main.set_visible(false);
+                no_downloaded_model.set_visible(false);
 
-                show!(no_model);
+                no_model.set_visible(true);
             }
             ComputedState::ModelSelectedWithEmptyChat => {
-                hide!(jump_to_bottom);
-                hide!(no_downloaded_model);
-                hide!(no_model);
+                jump_to_bottom.set_visible(false);
+                no_downloaded_model.set_visible(false);
+                no_model.set_visible(false);
 
-                show!(empty_conversation);
-                show!(main);
+                empty_conversation.set_visible(true);
+                main.set_visible(true);
             }
             ComputedState::ModelSelectedWithChat => {
-                hide!(empty_conversation);
-                hide!(no_downloaded_model);
-                hide!(no_model);
+                empty_conversation.set_visible(false);
+                no_downloaded_model.set_visible(false);
+                no_model.set_visible(false);
 
-                show!(main);
+                main.set_visible(true);
 
                 if self.portal_list(id!(chat)).further_items_bellow_exist() {
-                    show!(jump_to_bottom);
+                    jump_to_bottom.set_visible(true);
                 } else {
-                    hide!(jump_to_bottom);
+                    jump_to_bottom.set_visible(false);
                 }
             }
         }

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -502,7 +502,7 @@ impl Widget for ChatPanel {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.switch_visibilities(scope);
+        self.update_visibilities(scope);
 
         let store = scope.data.get_mut::<Store>().unwrap();
 
@@ -867,7 +867,7 @@ impl ChatPanel {
         };
     }
 
-    fn switch_visibilities(&mut self, scope: &mut Scope) {
+    fn update_visibilities(&mut self, scope: &mut Scope) {
         macro_rules! show {
             ($view_id:ident) => {
                 self.view(id!($view_id)).set_visible(true)

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -1,16 +1,21 @@
 use makepad_widgets::*;
 use moxin_protocol::data::FileID;
+use std::cell::{Ref, RefCell, RefMut};
 
 use crate::{
     chat::{
-        chat_history_card::ChatHistoryCardAction,
         chat_line::{ChatLineAction, ChatLineWidgetRefExt},
         model_selector::ModelSelectorWidgetExt,
         model_selector_list::ModelSelectorAction,
     },
-    data::store::Store,
+    data::{
+        chats::chat::{Chat, ChatMessage},
+        store::Store,
+    },
     shared::actions::ChatAction,
 };
+
+use super::chat_history_card::ChatHistoryCardAction;
 
 live_design! {
     import makepad_widgets::base::*;
@@ -407,7 +412,6 @@ live_design! {
                     height: Fill,
 
                     drag_scrolling: false,
-                    auto_tail: true,
 
                     UserChatLine = <UserChatLine> {}
                     ModelChatLine = <ModelChatLine> {}
@@ -423,19 +427,23 @@ live_design! {
     }
 }
 
-#[derive(PartialEq)]
-enum ChatPanelState {
-    Unload,
-    Idle,
-    Streaming {
-        auto_scroll_pending: bool,
-        auto_scroll_cancellable: bool,
+#[derive(Clone, Copy, Debug)]
+enum State {
+    /// `Unknown` is simply the default state, meaning the state has not been loaded yet,
+    /// and therefore indicates a development error if it is encountered.
+    Unknown,
+    NoModelsAvailable,
+    NoModelSelected,
+    ModelSelectedWithEmptyChat,
+    ModelSelectedWithChat {
+        sticked_to_bottom: bool,
+        is_streaming: bool,
     },
 }
 
-impl Default for ChatPanelState {
-    fn default() -> ChatPanelState {
-        ChatPanelState::Unload
+impl Default for State {
+    fn default() -> Self {
+        Self::Unknown
     }
 }
 
@@ -445,130 +453,43 @@ pub struct ChatPanel {
     view: View,
 
     #[rust]
-    state: ChatPanelState,
+    state: State,
 }
 
 impl Widget for ChatPanel {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        // Temporary fix, PR #98 will bring a better solution
-        if let Event::Startup = event {
-            let store = scope.data.get::<Store>().unwrap();
-            if store.get_loaded_downloaded_file().is_some() {
-                self.update_state_model_loaded(cx);
-            }
-        }
-
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
+        self.update_state(scope);
+        dbg!(self.state);
 
         if let Event::Signal = event {
-            let store = scope.data.get_mut::<Store>().unwrap();
-
             match self.state {
-                ChatPanelState::Streaming {
-                    auto_scroll_pending,
-                    auto_scroll_cancellable: _,
+                State::ModelSelectedWithChat {
+                    is_streaming: true,
+                    sticked_to_bottom,
                 } => {
-                    self.state = ChatPanelState::Streaming {
-                        auto_scroll_pending,
-                        auto_scroll_cancellable: true,
-                    };
-
-                    let still_streaming = store
-                        .chats
-                        .get_current_chat()
-                        .unwrap()
-                        .borrow()
-                        .is_streaming;
-                    if still_streaming {
-                        if auto_scroll_pending {
-                            self.scroll_messages_to_bottom(cx);
-                        }
-                    } else {
-                        // Scroll to the bottom when streaming is done
+                    if sticked_to_bottom {
                         self.scroll_messages_to_bottom(cx);
-                        self.state = ChatPanelState::Idle;
                     }
-
-                    self.update_prompt_input(cx);
 
                     // Redraw because we expect to see new or updated chat entries
                     self.redraw(cx);
                 }
-                ChatPanelState::Unload => self.unload_model(cx),
+                State::NoModelSelected => {
+                    self.unload_model(cx);
+                }
                 _ => {}
             }
         }
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.update_visibilities(scope);
-
-        let store = scope.data.get_mut::<Store>().unwrap();
-
-        // TODO: Rename "chat_history", "chat_count", etc, they are messages of a chat
-        // can be confused with the actual Chat type.
-        let chat_history;
-        if let Some(chat) = store.chats.get_current_chat() {
-            let model_filename = chat.borrow().model_filename.clone();
-            let initial_letter = get_initial_letter(&model_filename);
-            
-            chat_history = chat.borrow().messages.clone();
-            let chats_count = chat_history.len();
-            let chat_is_empty = chats_count == 0;
-            let model_loaded = store.get_loaded_downloaded_file().is_some();
-
-            let empty_conversation_view = self.view(id!(empty_conversation));
-            empty_conversation_view.set_visible(chat_is_empty && model_loaded);
-            if chat_is_empty {
-                empty_conversation_view
-                    .label(id!(avatar_label))
-                    .set_text(initial_letter.as_str());
-            }
-        } else {
-            chat_history = vec![];
-        }
+        self.update_view(cx, scope);
 
         while let Some(view_item) = self.view.draw_walk(cx, scope, walk).step() {
             if let Some(mut list) = view_item.as_portal_list().borrow_mut() {
-                let chats_count = chat_history.len();
-                list.set_item_range(cx, 0, chats_count);
-                while let Some(item_id) = list.next_visible_item(cx) {
-                    if item_id < chats_count {
-                        let chat_line_data = &chat_history[item_id];
-
-                        let item;
-                        let mut chat_line_item;
-                        if chat_line_data.is_assistant() {
-                            let username = chat_line_data.username.as_ref().map_or("", String::as_str);
-                            let initial_letter = get_initial_letter(username);
-
-                            item = list.item(cx, item_id, live_id!(ModelChatLine)).unwrap();
-                            chat_line_item = item.as_chat_line();
-                            chat_line_item.set_sender_name(&username);
-                            chat_line_item.set_regenerate_enabled(false);
-                            chat_line_item.set_avatar_text(&initial_letter);
-                        } else {
-                            item = list.item(cx, item_id, live_id!(UserChatLine)).unwrap();
-                            chat_line_item = item.as_chat_line();
-                            chat_line_item.set_regenerate_enabled(true);
-                        };
-
-                        chat_line_item.set_message_text(cx, &chat_line_data.content);
-                        chat_line_item.set_message_id(chat_line_data.id);
-
-                        // Disable actions for the last chat line when model is streaming
-                        if matches!(self.state, ChatPanelState::Streaming { .. })
-                            && item_id == chats_count - 1
-                        {
-                            chat_line_item.set_actions_enabled(cx, false);
-                        } else {
-                            chat_line_item.set_actions_enabled(cx, true);
-                        }
-
-                        item.draw_all(cx, &mut Scope::empty());
-                    }
-                }
+                self.draw_messages(cx, scope, &mut list);
             }
         }
 
@@ -579,119 +500,71 @@ impl Widget for ChatPanel {
 impl WidgetMatchEvent for ChatPanel {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let widget_uid = self.widget_uid();
+        let store = scope.data.get_mut::<Store>().unwrap();
 
-        for action in actions {
-            if let ChatHistoryCardAction::ChatSelected(_) = action.as_widget_action().cast() {
+        for action in actions
+            .iter()
+            .filter_map(|action| action.as_widget_action())
+        {
+            if let ChatHistoryCardAction::ChatSelected(_) = action.cast() {
                 self.redraw(cx);
-
-                // Temporary fix, PR #98 will bring a better solution
-                // let store = scope.data.get::<Store>().unwrap();
-                // if store.get_loaded_downloaded_file().is_some() {
-                //     self.update_state_model_loaded(cx);
-                // }
-            }
-
-            match action.as_widget_action().cast() {
-                ModelSelectorAction::Selected(downloaded_file) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    store.load_model(&downloaded_file.file);
-                    self.update_state_model_loaded(cx);
+            } else if let ModelSelectorAction::Selected(downloaded_file) = action.cast() {
+                store.load_model(&downloaded_file.file);
+                self.redraw(cx)
+            } else if let ChatAction::Start(file_id) = action.cast() {
+                let downloaded_file = store
+                    .downloads
+                    .downloaded_files
+                    .iter()
+                    .find(|file| file.file.id == file_id)
+                    .expect("Attempted to start chat with a no longer existing file")
+                    .clone();
+                
+                store.chats
+                    .create_empty_chat_with_model_file(&downloaded_file.file);
+            } else if let ChatAction::Resume(file_id) = action.cast() {
+                store.ensure_model_loaded_in_current_chat(file_id);
+            } else if let ChatLineAction::Delete(id) = action.cast() {
+                store.chats.delete_chat_message(id);
+                self.redraw(cx);
+            } else if let ChatLineAction::Edit(id, updated, regenerate) = action.cast() {
+                store.chats.edit_chat_message(id, updated, regenerate);
+                self.redraw(cx);
+            } else if let ChatPanelAction::UnloadIfActive(file_id) = action.cast() {
+                if store
+                    .chats
+                    .get_current_chat()
+                    .map_or(false, |chat| chat.borrow().file_id == file_id)
+                {
+                    self.unload_model(cx);
+                    store.chats.eject_model().expect("Failed to eject model");
                 }
-                _ => {}
-            }
-
-            match action.as_widget_action().cast() {
-                ChatAction::Start(file_id) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    let downloaded_file = store
-                        .downloads
-                        .downloaded_files
-                        .iter()
-                        .find(|file| file.file.id == file_id)
-                        .expect("Attempted to start chat with a no longer existing file")
-                        .clone();
-
-                    store
-                        .chats
-                        .create_empty_chat_with_model_file(&downloaded_file.file);
-                    self.update_state_model_loaded(cx);
-                }
-                ChatAction::Resume(file_id) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    store.ensure_model_loaded_in_current_chat(file_id);
-                }
-                _ => {}
-            }
-
-            match action.as_widget_action().cast() {
-                ChatLineAction::Delete(id) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    store.chats.delete_chat_message(id);
-                    self.redraw(cx);
-                }
-                ChatLineAction::Edit(id, updated, regenerate) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    store.chats.edit_chat_message(id, updated, regenerate);
-
-                    if regenerate {
-                        self.state = ChatPanelState::Streaming {
-                            auto_scroll_pending: true,
-                            auto_scroll_cancellable: false,
-                        };
-
-                        self.show_prompt_input_stop_icon(cx);
-
-                        let prompt_input = self.text_input(id!(main_prompt_input.prompt));
-                        prompt_input.set_text_and_redraw(cx, "");
-                        prompt_input.set_cursor(0, 0);
-                        self.update_prompt_input(cx);
-                    }
-                    self.redraw(cx);
-                }
-                _ => {}
-            }
-
-            match action.as_widget_action().cast() {
-                ChatPanelAction::UnloadIfActive(file_id) => {
-                    let store = scope.data.get_mut::<Store>().unwrap();
-                    if store
-                        .chats
-                        .get_current_chat()
-                        .map_or(false, |chat| chat.borrow().file_id == file_id)
-                    {
-                        self.unload_model(cx);
-                        store.chats.eject_model().expect("Failed to eject model");
-                    }
-                }
-                _ => {}
             }
         }
 
-        self.jump_to_bottom_actions(cx, actions);
+        if let Some(fe) = self.view(id!(jump_to_bottom)).finger_up(actions) {
+            if fe.was_tap() {
+                self.scroll_messages_to_bottom(cx);
+                self.redraw(cx);
+            }
+        }
 
         match self.state {
-            ChatPanelState::Idle => {
+            State::ModelSelectedWithChat {
+                is_streaming: false,
+                ..
+            }
+            | State::ModelSelectedWithEmptyChat => {
                 self.handle_prompt_input_actions(cx, actions, scope);
             }
-            ChatPanelState::Streaming {
-                auto_scroll_pending: _,
-                auto_scroll_cancellable,
+            State::ModelSelectedWithChat {
+                is_streaming: true, ..
             } => {
-                let list = self.portal_list(id!(chat));
-                if auto_scroll_cancellable && list.scrolled(actions) {
-                    // Cancel auto-scrolling if the user scrolls up
-                    self.state = ChatPanelState::Streaming {
-                        auto_scroll_pending: false,
-                        auto_scroll_cancellable,
-                    };
-                }
-
                 if let Some(fe) = self
                     .view(id!(main_prompt_input.prompt_icon))
                     .finger_up(actions)
                 {
                     if fe.was_tap() {
-                        let store = scope.data.get_mut::<Store>().unwrap();
                         store.chats.cancel_chat_streaming();
                     }
                 }
@@ -709,24 +582,44 @@ impl WidgetMatchEvent for ChatPanel {
 }
 
 impl ChatPanel {
-    fn jump_to_bottom_actions(&mut self, cx: &mut Cx, actions: &Actions) {
-        if let Some(fe) = self.view(id!(jump_to_bottom)).finger_up(actions) {
-            if fe.was_tap() {
-                self.scroll_messages_to_bottom(cx);
-                self.redraw(cx);
-            }
-        }
+    fn update_state(&mut self, scope: &mut Scope) {
+        let store = scope.data.get_mut::<Store>().unwrap();
+        let list = self.portal_list(id!(chat));
+
+        self.state = if store.downloads.downloaded_files.is_empty() {
+            State::NoModelsAvailable
+        } else if store.chats.loaded_model.is_none() {
+            State::NoModelSelected
+        } else {
+            store
+                .chats
+                .get_current_chat()
+                .map_or(State::ModelSelectedWithEmptyChat, |chat| {
+                    if chat.borrow().messages.is_empty() {
+                        State::ModelSelectedWithEmptyChat
+                    } else {
+                        State::ModelSelectedWithChat {
+                            sticked_to_bottom: !list.further_items_bellow_exist()
+                                || !matches!(self.state, State::ModelSelectedWithChat { .. }),
+                            is_streaming: chat.borrow().is_streaming,
+                        }
+                    }
+                })
+        };
     }
 
     fn update_prompt_input(&mut self, cx: &mut Cx) {
         match self.state {
-            ChatPanelState::Idle => {
+            State::ModelSelectedWithEmptyChat
+            | State::ModelSelectedWithChat {
+                is_streaming: false,
+                ..
+            } => {
                 self.enable_or_disable_prompt_input(cx);
                 self.show_prompt_input_send_icon(cx);
             }
-            ChatPanelState::Streaming {
-                auto_scroll_pending: _,
-                auto_scroll_cancellable: _,
+            State::ModelSelectedWithChat {
+                is_streaming: true, ..
             } => {
                 let prompt_input = self.text_input(id!(main_prompt_input.prompt));
                 prompt_input.apply_over(
@@ -813,19 +706,13 @@ impl ChatPanel {
         list.smooth_scroll_to_end(cx, 10, 80.0);
     }
 
-    fn update_state_model_loaded(&mut self, cx: &mut Cx) {
-        self.state = ChatPanelState::Idle;
-    }
-
     fn unload_model(&mut self, cx: &mut Cx) {
-        self.state = ChatPanelState::Unload;
         self.model_selector(id!(model_selector)).deselect(cx);
         self.view.redraw(cx);
     }
 
     fn handle_prompt_input_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let prompt_input = self.text_input(id!(main_prompt_input.prompt));
-
         if let Some(_text) = prompt_input.changed(actions) {
             self.update_prompt_input(cx);
         }
@@ -849,7 +736,6 @@ impl ChatPanel {
             return;
         }
 
-        self.show_prompt_input_stop_icon(cx);
         let store = scope.data.get_mut::<Store>().unwrap();
         store.chats.send_chat_message(prompt.clone());
 
@@ -860,48 +746,33 @@ impl ChatPanel {
 
         // Scroll to the bottom when the message is sent
         self.scroll_messages_to_bottom(cx);
-
-        self.state = ChatPanelState::Streaming {
-            auto_scroll_pending: true,
-            auto_scroll_cancellable: false,
-        };
     }
 
-    fn update_visibilities(&mut self, scope: &mut Scope) {
-        let store = scope.data.get_mut::<Store>().unwrap();
+    fn update_view(&mut self, cx: &mut Cx2d, scope: &mut Scope) {
+        self.update_visibilities();
+        self.update_prompt_input(cx);
 
-        enum ComputedState {
-            NoModelsAvailable,
-            NoModelSelected,
-            ModelSelectedWithEmptyChat,
-            ModelSelectedWithChat,
+        match self.state {
+            State::ModelSelectedWithEmptyChat => {
+                let store = scope.data.get::<Store>().unwrap();
+
+                self.view(id!(empty_conversation))
+                    .label(id!(avatar_label))
+                    .set_text(&get_model_initial_letter(store).unwrap().to_string());
+            }
+            _ => {}
         }
+    }
 
-        let state = if store.downloads.downloaded_files.is_empty() {
-            ComputedState::NoModelsAvailable
-        } else if store.chats.loaded_model.is_none() {
-            ComputedState::NoModelSelected
-        } else {
-            store.chats.get_current_chat().map_or(
-                ComputedState::ModelSelectedWithEmptyChat,
-                |chat| {
-                    if chat.borrow().messages.is_empty() {
-                        ComputedState::ModelSelectedWithEmptyChat
-                    } else {
-                        ComputedState::ModelSelectedWithChat
-                    }
-                },
-            )
-        };
-
+    fn update_visibilities(&mut self) {
         let empty_conversation = self.view(id!(empty_conversation));
         let jump_to_bottom = self.view(id!(jump_to_bottom));
         let main = self.view(id!(main));
         let no_downloaded_model = self.view(id!(no_downloaded_model));
         let no_model = self.view(id!(no_model));
 
-        match state {
-            ComputedState::NoModelsAvailable => {
+        match self.state {
+            State::NoModelsAvailable => {
                 empty_conversation.set_visible(false);
                 jump_to_bottom.set_visible(false);
                 main.set_visible(false);
@@ -909,7 +780,7 @@ impl ChatPanel {
 
                 no_downloaded_model.set_visible(true);
             }
-            ComputedState::NoModelSelected => {
+            State::NoModelSelected => {
                 empty_conversation.set_visible(false);
                 jump_to_bottom.set_visible(false);
                 main.set_visible(false);
@@ -917,7 +788,7 @@ impl ChatPanel {
 
                 no_model.set_visible(true);
             }
-            ComputedState::ModelSelectedWithEmptyChat => {
+            State::ModelSelectedWithEmptyChat => {
                 jump_to_bottom.set_visible(false);
                 no_downloaded_model.set_visible(false);
                 no_model.set_visible(false);
@@ -925,18 +796,70 @@ impl ChatPanel {
                 empty_conversation.set_visible(true);
                 main.set_visible(true);
             }
-            ComputedState::ModelSelectedWithChat => {
+            State::ModelSelectedWithChat {
+                sticked_to_bottom, ..
+            } => {
                 empty_conversation.set_visible(false);
                 no_downloaded_model.set_visible(false);
                 no_model.set_visible(false);
 
                 main.set_visible(true);
 
-                if self.portal_list(id!(chat)).further_items_bellow_exist() {
-                    jump_to_bottom.set_visible(true);
-                } else {
+                if sticked_to_bottom {
                     jump_to_bottom.set_visible(false);
+                } else {
+                    jump_to_bottom.set_visible(true);
                 }
+            }
+            _ => {}
+        }
+    }
+
+    fn draw_messages(&self, cx: &mut Cx2d, scope: &mut Scope, list: &mut RefMut<PortalList>) {
+        let store = scope.data.get::<Store>().unwrap();
+        let messages = get_chat_messages(store).unwrap();
+        let messages_count = messages.len();
+
+        list.set_item_range(cx, 0, messages_count);
+        while let Some(item_id) = list.next_visible_item(cx) {
+            if item_id < messages_count {
+                let chat_line_data = &messages[item_id];
+
+                let item;
+                let mut chat_line_item;
+                if chat_line_data.is_assistant() {
+                    item = list.item(cx, item_id, live_id!(ModelChatLine)).unwrap();
+                    chat_line_item = item.as_chat_line();
+
+                    let username = chat_line_data.username.as_ref().map_or("", String::as_str);
+                    chat_line_item.set_sender_name(&username);
+                    chat_line_item.set_regenerate_enabled(false);
+                    chat_line_item
+                        .set_avatar_text(&get_initial_letter(username).unwrap().to_string());
+                } else {
+                    item = list.item(cx, item_id, live_id!(UserChatLine)).unwrap();
+                    chat_line_item = item.as_chat_line();
+                    chat_line_item.set_regenerate_enabled(true);
+                };
+
+                chat_line_item.set_message_text(cx, &chat_line_data.content);
+                chat_line_item.set_message_id(chat_line_data.id);
+
+                // Disable actions for the last chat line when model is streaming
+                if matches!(
+                    self.state,
+                    State::ModelSelectedWithChat {
+                        is_streaming: true,
+                        ..
+                    }
+                ) && item_id == messages_count - 1
+                {
+                    chat_line_item.set_actions_enabled(cx, false);
+                } else {
+                    chat_line_item.set_actions_enabled(cx, true);
+                }
+
+                item.draw_all(cx, &mut Scope::empty());
             }
         }
     }
@@ -949,10 +872,20 @@ pub enum ChatPanelAction {
     None,
 }
 
-fn get_initial_letter(word: &str) -> String {
-    word.chars()
-        .next()
-        .unwrap_or_default()
-        .to_uppercase()
-        .to_string()
+fn get_chat(store: &Store) -> Option<&RefCell<Chat>> {
+    store.chats.get_current_chat()
+}
+
+fn get_initial_letter(word: &str) -> Option<char> {
+    word.chars().next()
+}
+
+fn get_model_initial_letter(store: &Store) -> Option<char> {
+    let chat = get_chat(store)?;
+    let initial_letter = get_initial_letter(&chat.borrow().model_filename)?;
+    Some(initial_letter.to_ascii_uppercase())
+}
+
+fn get_chat_messages(store: &Store) -> Option<Ref<Vec<ChatMessage>>> {
+    get_chat(store).map(|chat| Ref::map(chat.borrow(), |chat| &chat.messages))
 }

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -880,12 +880,6 @@ impl ChatPanel {
             };
         }
 
-        match self.state {
-            ChatPanelState::Idle => show!(main),
-            ChatPanelState::Unload => hide!(main),
-            _ => {}
-        }
-
         let store = scope.data.get_mut::<Store>().unwrap();
 
         enum ComputedState {
@@ -918,23 +912,27 @@ impl ChatPanel {
                 hide!(no_model);
                 hide!(empty_conversation);
                 hide!(jump_to_bottom);
+                hide!(main);
             }
             ComputedState::NoModelSelected => {
                 hide!(no_downloaded_model);
                 show!(no_model);
                 hide!(empty_conversation);
                 hide!(jump_to_bottom);
+                hide!(main);
             }
             ComputedState::ModelSelectedWithEmptyChat => {
                 hide!(no_downloaded_model);
                 hide!(no_model);
                 show!(empty_conversation);
                 hide!(jump_to_bottom);
+                show!(main);
             }
             ComputedState::ModelSelectedWithChat => {
                 hide!(no_downloaded_model);
                 hide!(no_model);
                 hide!(empty_conversation);
+                show!(main);
 
                 if self.portal_list(id!(chat)).further_items_bellow_exist() {
                     show!(jump_to_bottom);

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -908,30 +908,34 @@ impl ChatPanel {
 
         match state {
             ComputedState::NoModelsAvailable => {
-                show!(no_downloaded_model);
-                hide!(no_model);
                 hide!(empty_conversation);
                 hide!(jump_to_bottom);
                 hide!(main);
+                hide!(no_model);
+
+                show!(no_downloaded_model);
             }
             ComputedState::NoModelSelected => {
-                hide!(no_downloaded_model);
-                show!(no_model);
                 hide!(empty_conversation);
                 hide!(jump_to_bottom);
                 hide!(main);
+                hide!(no_downloaded_model);
+
+                show!(no_model);
             }
             ComputedState::ModelSelectedWithEmptyChat => {
+                hide!(jump_to_bottom);
                 hide!(no_downloaded_model);
                 hide!(no_model);
+
                 show!(empty_conversation);
-                hide!(jump_to_bottom);
                 show!(main);
             }
             ComputedState::ModelSelectedWithChat => {
+                hide!(empty_conversation);
                 hide!(no_downloaded_model);
                 hide!(no_model);
-                hide!(empty_conversation);
+
                 show!(main);
 
                 if self.portal_list(id!(chat)).further_items_bellow_exist() {


### PR DESCRIPTION
# Changes

- Centralized everything mutating visibility states of chat panel into a single method so it's easier to debug and to define what is shown in each possible state.
- Fixed multiple visibility overlap bugs.
- Model selector initially empty and visible.
- As agreed , state is kept in the widget as it was before giving the chance to change it from there, but is computed from store when an event happens (the mouse is moved, or whatever).
- Improved autoscroll behavior a bit. Autoscroll should now be reliable if you never scrolled up or if you did but pressed the jump to bottom button. Other issues are harder to fix without modifying the portal list widget.
