### PR TITLE
Rename binaries to avoid accidental invocation of the moxin app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "crossbeam",
- "directories",
  "futures-util",
  "log",
  "moxin-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ version = "0.1.0"
 edition = "2021"
 description = "A desktop GUI client for downloading and chatting with AI LLMs"
 
+## Rename the binary to `_moxin_app` to avoid naming conflicts
+## with the `moxin` binary defined by the `moxin-runner` crate.
+[[bin]]
+name = "_moxin_app"
+path = "src/main.rs"
+
+
 [dependencies]
 moxin-protocol = { path = "moxin-protocol" }
 moxin-backend = { path = "moxin-backend" }
@@ -54,9 +61,14 @@ publisher = "moxin-org"
 homepage = "https://github.com/moxin-org"
 icons = ["app_icon128x128.png"]
 out_dir = "./dist"
+## Note: the `moxin-runner` crate binary is named `moxin`,
+##       while the main `moxin` crate binary is named `_moxin_app`.
+##       This is to avoid naming conflicts when packaging the binaries,
+##       and also ensures that the `moxin-runner` binary is the "main" binary
+##       that gets executed when the user runs "moxin" from the command line.
 binaries = [
-    { path = "moxin-runner", main = true },
-    { path = "moxin", main = false },
+    { path = "moxin", main = true },
+    { path = "_moxin_app", main = false },
 ]
 
 ## See the below paragraph comments for more info on how we determine these `src` directories.

--- a/moxin-backend/Cargo.toml
+++ b/moxin-backend/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 moxin-protocol = { path = "../moxin-protocol" }
 chrono = "0.4"
-directories = "5.0.1"
 wasmedge-sdk = { version = "=0.13.5-newapi", default-features = false, features = [
     "wasi_nn",
 ] }

--- a/moxin-backend/src/lib.rs
+++ b/moxin-backend/src/lib.rs
@@ -2,8 +2,7 @@ mod backend_impls;
 mod store;
 
 use moxin_protocol::protocol::Command;
-use std::{path::Path, sync::{mpsc, OnceLock}};
-use directories::ProjectDirs;
+use std::{path::Path, sync::mpsc};
 
 pub struct Backend {
     pub command_sender: mpsc::Sender<Command>,

--- a/moxin-runner/Cargo.toml
+++ b/moxin-runner/Cargo.toml
@@ -6,3 +6,7 @@ description = "A companion app that runs before Moxin to handle wasmedge configu
 
 [dependencies]
 directories = "5.0.1"
+
+[[bin]]
+name = "moxin"
+path = "src/main.rs"

--- a/moxin-runner/src/main.rs
+++ b/moxin-runner/src/main.rs
@@ -61,6 +61,8 @@ use std::{
     process::{Command, Stdio},
 };
 
+pub const MOXIN_APP_BINARY: &str = "_moxin_app";
+
 const WASMEDGE_DIR_NAME: &str = ".wasmedge";
 const LIB_DIR_NAME: &str = "lib";
 const PLUGIN_DIR_NAME: &str = "plugin";
@@ -289,14 +291,14 @@ fn wasmedge_dir_from_env_vars() -> Option<PathBuf> {
         )
 }
 
-/// Runs the moxin app binary, which must be located in the same directory as this moxin-runner binary.
+/// Runs the `_moxin_app` binary, which must be located in the same directory as this moxin-runner binary.
 fn run_moxin() -> std::io::Result<()> {
     let current_exe = std::env::current_exe()?;
     let current_exe_dir = current_exe.parent().unwrap();
     
     println!("Running moxin in dir: {}", current_exe_dir.display());
 
-    let _output = Command::new(current_exe_dir.join("moxin"))
+    let _output = Command::new(current_exe_dir.join(MOXIN_APP_BINARY))
         .current_dir(current_exe_dir)
         .spawn()?
         .wait_with_output()?;


### PR DESCRIPTION
This most commonly occurs in an environment where the app was installed by a packaged installer.

* The moxin crate now generates a binary called `_moxin_app`, which intentionally does not begin with moxin, such that a shell autocomplete does not suggest both "moxin" and "moxin-runner", which is confusing and misleading, because directly running "moxin" previously would not work.
* The moxin-runner crate now generates a binary called `moxin`, which ensures that if a user runs the `moxin` command, everything still works as intended.
* These changes still allow `cargo run` to work as normal, in addition to
  `cargo run -p moxin-runner`.

* Removed unnecessary dependencies; addressed a few minor warnings.
