### PR TITLE
Remove outdated parts of README about running macOS app bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,26 +100,6 @@ You can immediately double-click the `Moxin.app` bundle to run it, or you can do
 
 If you'd like to modify the .dmg background, here is the [Google Drawings file used to generate the MacOS .dmg background image](https://docs.google.com/drawings/d/1Uq13nAsCKFrl4s16HeLqpVfQ-vbF7v2Z8HFyqgeyrbE/edit?usp=sharing).
 
-### Installing and running the packaged macOS app
-> [!IMPORTANT]
-> The Moxin application package on macOS is currently not signed, so Apple will display a warning on macOS (shown below) when you first attempt to open it after installation.
->
-> **This warning is not true**. The app is not damaged, it just hasn't been signed.
-
-<img src="macOS_error.png" alt="macOS error for Moxin app" />
-
-To get around this, do the following:
-* Install the Moxin app as normal by opening the `.dmg` and dragging the Moxin app to the Applications folder shortcut.
-* Open the Moxin app from your Applications folder.
-* An error message will pop up, as described above. **Click cancel**.
-* Open a terminal and run the following command:
-  ```sh
-  xattr -dr com.apple.quarantine path/to/the/installed/Moxin.app
-  ```
-  * The path is typically `/Applications/Moxin.app`, assuming you dragged the app icon into the Applications folder.
-* Now open the Moxin app again as normal, it should work as expected.
-
-
 
 [`.dmg`]: https://support.apple.com/en-gb/guide/mac-help/mh35835/mac
 [`.deb` (Debian dpkg)]: https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html#package


### PR DESCRIPTION
Codesigning/notarization now works as expected, so these warnings will not show up.