### PR TITLE
Use `robius-url-handler` to handle incoming URLs with scheme `moxin://`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,7 +773,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb69199826926eb864697bddd27f73d9fddcffc004f5733131e15b465e30642"
 dependencies = [
- "block2",
+ "block2 0.4.0",
  "objc2",
 ]
 
@@ -1246,6 +1255,7 @@ dependencies = [
  "moxin-protocol",
  "rand",
  "robius-open",
+ "robius-url-handler",
  "serde",
  "serde_json",
  "unicode-segmentation",
@@ -1354,15 +1364,15 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da284c198fb9b7b0603f8635185e85fbd5b64ee154b1ed406d489077de2d6d60"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b25e1034d0e636cd84707ccdaa9f81243d399196b8a773946dcffec0401659"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
  "objc-sys",
  "objc2-encode",
@@ -1370,9 +1380,21 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.1"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88658da63e4cc2c8adb1262902cd6af51094df0488b760d6fd27194269c0950a"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "object"
@@ -1727,6 +1749,17 @@ dependencies = [
  "jni",
  "objc2",
  "robius-android-env",
+]
+
+[[package]]
+name = "robius-url-handler"
+version = "0.1.0"
+source = "git+https://github.com/project-robius/robius-url-handler#a31f86f42cda993e9c1beb03b7f538e9ee0270be"
+dependencies = [
+ "cfg-if",
+ "objc2",
+ "objc2-foundation",
+ "windows",
 ]
 
 [[package]]
@@ -2543,6 +2576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "git+https://github.com/jmbejar/makepad?branch=moxin-release-v1#207be72ab09c16b259a972f1de0c938779c1b7d4"
@@ -2555,6 +2598,49 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ moxin-fake-backend = { path = "moxin-fake-backend" }
 makepad-widgets = { git = "https://github.com/jmbejar/makepad", branch = "moxin-release-v1" }
 
 robius-open = "0.1.0"
+robius-url-handler = { git = "https://github.com/project-robius/robius-url-handler" }
 
 chrono = "0.4"
 directories = "5.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,20 @@
+use std::io::Write;
+
 fn main() {
-    println!("Moxin was invoked with args: {:#?}", std::env::args().collect::<Vec<_>>());
+    robius_url_handler::register_handler(|incoming_url| {
+        // Note: here is where the URL should be acted upon.
+        // Currently, we just log it to a temp file to prove that it works.
+        let tmp = std::env::temp_dir();
+        let now = std::time::SystemTime::now();
+        std::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(tmp.join("moxin_incoming_url.txt"))
+            .and_then(|mut f| 
+                f.write_all(format!("[{now:?}] Received incoming URL: {incoming_url:?}\n\n").as_bytes())
+            )
+            .unwrap();
+    });
 
     moxin::app::app_main()
 }


### PR DESCRIPTION
Tested working on Debian-like Linux and macOS.

Note that this functionality will only work for properly packaged application bundles (i.e., using cargo-packager) that have been installed on your system, e.g., using `sudo dpkg -i` on Linux or installing the app bundle via the `moxin-*.dmg` disk image on macOS.

On Linux, the handled URLs are appended to the file `/tmp/moxin_incoming_url.txt`.
On macOS, that file is located at `$TMPDIR/moxin_incoming_url.txt`.