### PR TITLE
Linux: update .desktop file to support handling multiple URLs and define WMClass

### DIFF
--- a/packaging/moxin.desktop
+++ b/packaging/moxin.desktop
@@ -3,11 +3,12 @@ Categories={{categories}}
 {{#if comment}}
 Comment={{comment}}
 {{/if}}
-Exec={{exec}} %u
+Exec={{exec}} %U
 Icon={{icon}}
 Name={{name}}
 Terminal=false
 Type=Application
+StartupWMClass={{name}}
 {{#if mime_type}}
 MimeType={{mime_type}}
 {{/if}}


### PR DESCRIPTION
Defining the `StartupWMClass` should allow windows to be properly grouped, once we add support for that into Makepad's X window handling.