### PR TITLE
Auto-determine dependencies for Linux packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,8 @@ resources = [
 ##   which is currently `/usr/lib/moxin-runner`.
 ##   This is the directory in which `dpkg` copies app resource files to when installing the `.deb` package.
 ##   * On Linux, we also strip the binaries of unneeded content, as required for Debian packages.
+##   * For Debian and Pacman packages, we also auto-generate the list of dependencies required by moxin,
+##     making sure to add `curl` since it is used by an invocation in `moxin-runner`.
 ##
 before-each-package-command = """
 export CARGO_PACKAGER_HOST_OS=`rustc --print cfg | grep target_os= | sed -e 's/target_os=\"//g' -e 's/\"//g'`; \
@@ -130,7 +132,14 @@ elif [ "$CARGO_PACKAGER_HOST_OS" = linux ]; then \
     if [ "$CARGO_PACKAGER_FORMAT" = appimage ]; then \
         MAKEPAD_PACKAGE_DIR=../../usr/lib/moxin  cargo build --workspace --release; \
     else \
-        MAKEPAD_PACKAGE_DIR=/usr/lib/moxin  cargo build --workspace --release; \
+        MAKEPAD_PACKAGE_DIR=/usr/lib/moxin  cargo build --workspace --release --features "reqwest/native-tls-vendored"; \
+        if [ "$CARGO_PACKAGER_FORMAT" = deb ]; then \
+            for path in $(ldd target/release/_moxin_app | awk '{print $3}'); do \
+                basename "$path" ; \
+            done \
+                | xargs dpkg -S 2> /dev/null | awk '{print $1}' | awk -F ':' '{print $1}' | sort | uniq > ./dist/depends_deb.txt; \
+            echo "curl" >> ./dist/depends_deb.txt; \
+        fi; \
     fi \
     && strip --strip-unneeded --remove-section=.comment --remove-section=.note target/release/_moxin_app target/release/moxin; \
 else exit 2; \
@@ -142,8 +151,13 @@ deep_link_protocols = [
 ]
 
 [package.metadata.packager.deb]
+depends = "./dist/depends_deb.txt" ## must include `curl`, as needed by `moxin-runner`
 desktop_template = "./packaging/moxin.desktop"
 section = "utils"
+
+[package.metadata.packager.appimage]
+## `curl` is needed for `moxin-runner` to auto-install wasmedge.
+bins = [ "/usr/bin/curl" ]
 
 [package.metadata.packager.macos]
 minimum_system_version = "11.0"

--- a/README.md
+++ b/README.md
@@ -57,11 +57,10 @@ cargo run
 
 ## Packaging Moxin for Distribution
 
-Install cargo packager:
+Install the following version of `cargo-packager`:
 ```sh
-cargo install --force --locked --git https://github.com/project-robius/cargo-packager cargo-packager
+cargo install --force --locked --git https://github.com/project-robius/cargo-packager cargo-packager --rev 596c5a418f26ab511447a23ba9687a056598227f
 ```
-For the sake of posterity, these instructions were tested with [this commit](https://github.com/project-robius/cargo-packager/commit/9cce648e44303b927911fa8971af3d9e55af19fe) of cargo-packager.
 
 
 ### Packaging for Linux
@@ -72,8 +71,10 @@ On a Debian-based Linux distribution (e.g., Ubuntu), you can generate a `.deb` D
 To install the Moxin app from the `.deb`package on a Debian-based Linux distribution (e.g., Ubuntu), run:
 ```sh
 cd dist/
-sudo dpkg -i moxin_0.1.0_amd64.deb  ## requires entering your password
+sudo apt install ./moxin_0.1.0_amd64.deb  ## The "./" part is required
 ```
+We recommend using `apt install` to install the `.deb` file instead of `dpkg -i`, because `apt` will auto-install all of Moxin's required dependencies, whereas `dpkg` will require you to install them manually.
+
 
 To run the AppImage bundle, simply set the file as executable and then run it:
 ```sh


### PR DESCRIPTION
These are now specified for Debian and Pacman packages.

Uses a new version of cargo-packager, as now specified in the README.

Also fixes AppImage packages to _always_ work even on a fresh Linux install.