### PR TITLE
Support chat responses when stream option is off

### DIFF
--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -251,6 +251,14 @@ impl Chat {
                             break;
                         }
                     }
+                    Ok(ChatResponse::ChatFinalResponseData(data)) => {
+                        let _ = store_chat_tx.send(ChatTokenArrivalAction::AppendDelta(
+                            data.choices[0].message.content.clone(),
+                        ));
+                        let _ = store_chat_tx.send(ChatTokenArrivalAction::StreamingDone);
+                        SignalToUI::set_ui_signal();
+                        break;
+                    }
                     Err(err) => eprintln!("Error receiving response chunk: {:?}", err),
                     _ => (),
                 }


### PR DESCRIPTION
This adds support for chat interactions without streaming responses. #133 is adding a settings form with a toggle option to turn on/off the streaming, so it will be testable when it gets merged.