### PR TITLE
Avoid redraw call in render logic in Chat

### DIFF
--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -332,8 +332,6 @@ impl ChatLine {
             .set_visible(show && is_plain_text);
         self.view(id!(markdown_message_container))
             .set_visible(show && !is_plain_text);
-
-        self.redraw(cx);
     }
 
     pub fn handle_editable_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {


### PR DESCRIPTION
I was debugging the Chat screen and confirmed we had a `self.redraw(cx)` in a function that was called (indirectly) from a `draw_widget` function body. This change should not affect anything, but let's confirm with more testing.