### PR TITLE
Last selected chat memory

### DIFF
--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -7,7 +7,6 @@ use moxin_protocol::protocol::Command;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -102,10 +101,7 @@ impl Chat {
         let (tx, rx) = channel();
 
         // Get Unix timestamp in ms for id.
-        let id = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Couldn't get Unix timestamp, time went backwards")
-            .as_millis();
+        let id = chrono::Utc::now().timestamp_millis() as u128;
 
         Self {
             id,

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -50,6 +50,9 @@ struct ChatData {
     title: String,
     #[serde(default)]
     title_state: TitleState,
+    // Default for backwards compatibility.
+    #[serde(default = "chrono::Utc::now")]
+    last_selected_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug)]
@@ -87,6 +90,7 @@ pub struct Chat {
     pub messages_update_receiver: Receiver<ChatTokenArrivalAction>,
     pub is_streaming: bool,
     pub inferences_params: ChatInferenceParams,
+    pub last_selected_at: chrono::DateTime<chrono::Utc>,
 
     title: String,
     title_state: TitleState,
@@ -115,6 +119,7 @@ impl Chat {
             title_state: TitleState::default(),
             chats_dir,
             inferences_params: ChatInferenceParams::default(),
+            last_selected_at: chrono::Utc::now(),
         }
     }
 
@@ -135,6 +140,7 @@ impl Chat {
                     messages_update_receiver: rx,
                     chats_dir,
                     inferences_params: ChatInferenceParams::default(),
+                    last_selected_at: data.last_selected_at,
                 };
                 Ok(chat)
             }
@@ -149,6 +155,7 @@ impl Chat {
             messages: self.messages.clone(),
             title: self.title.clone(),
             title_state: self.title_state,
+            last_selected_at: self.last_selected_at,
         };
         let json = serde_json::to_string(&data).unwrap();
         let path = self.chats_dir.join(self.file_name());
@@ -342,5 +349,9 @@ impl Chat {
             .position(|m| m.id == message_id)
             .unwrap();
         self.messages.truncate(message_index);
+    }
+
+    pub fn touch_last_selected_at(&mut self) {
+        self.last_selected_at = chrono::Utc::now();
     }
 }

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -50,7 +50,7 @@ struct ChatData {
     #[serde(default)]
     title_state: TitleState,
     #[serde(default)]
-    last_selected_at: chrono::DateTime<chrono::Utc>,
+    accessed_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug)]
@@ -88,7 +88,7 @@ pub struct Chat {
     pub messages_update_receiver: Receiver<ChatTokenArrivalAction>,
     pub is_streaming: bool,
     pub inferences_params: ChatInferenceParams,
-    pub last_selected_at: chrono::DateTime<chrono::Utc>,
+    pub accessed_at: chrono::DateTime<chrono::Utc>,
 
     title: String,
     title_state: TitleState,
@@ -114,7 +114,7 @@ impl Chat {
             title_state: TitleState::default(),
             chats_dir,
             inferences_params: ChatInferenceParams::default(),
-            last_selected_at: chrono::Utc::now(),
+            accessed_at: chrono::Utc::now(),
         }
     }
 
@@ -135,7 +135,7 @@ impl Chat {
                     messages_update_receiver: rx,
                     chats_dir,
                     inferences_params: ChatInferenceParams::default(),
-                    last_selected_at: data.last_selected_at,
+                    accessed_at: data.accessed_at,
                 };
                 Ok(chat)
             }
@@ -150,7 +150,7 @@ impl Chat {
             messages: self.messages.clone(),
             title: self.title.clone(),
             title_state: self.title_state,
-            last_selected_at: self.last_selected_at,
+            accessed_at: self.accessed_at,
         };
         let json = serde_json::to_string(&data).unwrap();
         let path = self.chats_dir.join(self.file_name());
@@ -346,7 +346,7 @@ impl Chat {
         self.messages.truncate(message_index);
     }
 
-    pub fn touch_last_selected_at(&mut self) {
-        self.last_selected_at = chrono::Utc::now();
+    pub fn update_accessed_at(&mut self) {
+        self.accessed_at = chrono::Utc::now();
     }
 }

--- a/src/data/chats/chat.rs
+++ b/src/data/chats/chat.rs
@@ -50,8 +50,7 @@ struct ChatData {
     title: String,
     #[serde(default)]
     title_state: TitleState,
-    // Default for backwards compatibility.
-    #[serde(default = "chrono::Utc::now")]
+    #[serde(default)]
     last_selected_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -105,13 +105,15 @@ impl Chats {
     }
 
     pub fn get_chat_by_id(&self, chat_id: ChatID) -> Option<&RefCell<Chat>> {
-        self.saved_chats
-                .iter()
-                .find(|c| c.borrow().id == chat_id)
+        self.saved_chats.iter().find(|c| c.borrow().id == chat_id)
     }
 
     pub fn set_current_chat(&mut self, chat_id: ChatID) {
         self.current_chat_id = Some(chat_id);
+        self.get_current_chat()
+            .unwrap()
+            .borrow_mut()
+            .touch_last_selected_at();
     }
 
     pub fn send_chat_message(&mut self, prompt: String) {

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -44,7 +44,7 @@ impl Chats {
         }
     }
 
-    pub fn get_last_selected_chat_id(&mut self) -> Option<ChatID> {
+    pub fn get_last_selected_chat_id(&self) -> Option<ChatID> {
         self.saved_chats
             .iter()
             .max_by_key(|c| c.borrow().last_selected_at)

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -44,10 +44,11 @@ impl Chats {
         }
     }
 
-    pub fn get_latest_chat_id(&mut self) -> Option<ChatID> {
+    pub fn get_last_selected_chat_id(&mut self) -> Option<ChatID> {
         self.saved_chats
-            .sort_by(|a, b| a.borrow().id.cmp(&b.borrow().id));
-        self.saved_chats.last().map(|c| c.borrow().id.clone())
+            .iter()
+            .max_by_key(|c| c.borrow().last_selected_at)
+            .map(|c| c.borrow().id)
     }
 
     pub fn load_model(&mut self, file: &File) -> Result<()> {
@@ -220,7 +221,7 @@ impl Chats {
 
         if let Some(current_chat_id) = self.current_chat_id {
             if current_chat_id == chat_id {
-                self.current_chat_id = self.get_latest_chat_id();
+                self.current_chat_id = self.get_last_selected_chat_id();
             }
         }
     }

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -110,10 +110,10 @@ impl Chats {
 
     pub fn set_current_chat(&mut self, chat_id: ChatID) {
         self.current_chat_id = Some(chat_id);
-        self.get_current_chat()
-            .unwrap()
-            .borrow_mut()
-            .touch_last_selected_at();
+
+        let mut chat = self.get_current_chat().unwrap().borrow_mut();
+        chat.touch_last_selected_at();
+        chat.save();
     }
 
     pub fn send_chat_message(&mut self, prompt: String) {

--- a/src/data/chats/mod.rs
+++ b/src/data/chats/mod.rs
@@ -47,7 +47,7 @@ impl Chats {
     pub fn get_last_selected_chat_id(&self) -> Option<ChatID> {
         self.saved_chats
             .iter()
-            .max_by_key(|c| c.borrow().last_selected_at)
+            .max_by_key(|c| c.borrow().accessed_at)
             .map(|c| c.borrow().id)
     }
 
@@ -113,7 +113,7 @@ impl Chats {
         self.current_chat_id = Some(chat_id);
 
         let mut chat = self.get_current_chat().unwrap().borrow_mut();
-        chat.touch_last_selected_at();
+        chat.update_accessed_at();
         chat.save();
     }
 

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -257,7 +257,7 @@ impl Store {
     }
 
     fn init_current_chat(&mut self) {
-        if let Some(chat_id) = self.chats.get_latest_chat_id() {
+        if let Some(chat_id) = self.chats.get_last_selected_chat_id() {
             self.select_chat(chat_id);
         } else {
             self.chats.create_empty_chat();


### PR DESCRIPTION
# Changes
- Keep track of the last time a chat has been selected.
- Load the last selected chat on app start.
- Bonus: When deleting the chat, move to the previous one you had selected.
  - This change lets me remove the last created chat id function that I think was only being relevant for this arbitrary behavior.
  
# Recording

https://github.com/moxin-org/moxin/assets/7684329/efc61e45-d8f1-4b1b-a69a-6a598d459482

