### PR TITLE
Fix jump to bottom flicker

### DIFF
--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -395,6 +395,7 @@ live_design! {
 
                     UserChatLine = <UserChatLine> {}
                     ModelChatLine = <ModelChatLine> {}
+                    EndOfChat = <View> {height: 0.1}
                 }
 
                 <JumpToButtom> {}
@@ -429,6 +430,9 @@ pub struct ChatPanel {
 
     #[rust]
     state: State,
+
+    #[rust]
+    portal_list_end_reached: bool,
 }
 
 impl Widget for ChatPanel {
@@ -567,7 +571,6 @@ impl WidgetMatchEvent for ChatPanel {
 impl ChatPanel {
     fn update_state(&mut self, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
-        let list = self.portal_list(id!(chat));
 
         self.state = if store.downloads.downloaded_files.is_empty() {
             State::NoModelsAvailable
@@ -582,7 +585,7 @@ impl ChatPanel {
                         State::ModelSelectedWithEmptyChat
                     } else {
                         State::ModelSelectedWithChat {
-                            sticked_to_bottom: !list.further_items_bellow_exist()
+                            sticked_to_bottom: self.portal_list_end_reached
                                 || !matches!(self.state, State::ModelSelectedWithChat { .. }),
                             is_streaming: chat.borrow().is_streaming,
                         }
@@ -820,13 +823,20 @@ impl ChatPanel {
         }
     }
 
-    fn draw_messages(&self, cx: &mut Cx2d, scope: &mut Scope, list: &mut RefMut<PortalList>) {
+    fn draw_messages(&mut self, cx: &mut Cx2d, scope: &mut Scope, list: &mut RefMut<PortalList>) {
         let store = scope.data.get::<Store>().unwrap();
         let messages = get_chat_messages(store).unwrap();
         let messages_count = messages.len();
 
-        list.set_item_range(cx, 0, messages_count);
+        self.portal_list_end_reached = false;
+        list.set_item_range(cx, 0, messages_count + 1);
         while let Some(item_id) = list.next_visible_item(cx) {
+            if item_id == messages_count {
+                self.portal_list_end_reached = true;
+                let item = list.item(cx, item_id, live_id!(EndOfChat)).unwrap();
+                item.draw_all(cx, &mut Scope::empty());
+            }
+
             if item_id < messages_count {
                 let chat_line_data = &messages[item_id];
 

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -831,12 +831,6 @@ impl ChatPanel {
         self.portal_list_end_reached = false;
         list.set_item_range(cx, 0, messages_count + 1);
         while let Some(item_id) = list.next_visible_item(cx) {
-            if item_id == messages_count {
-                self.portal_list_end_reached = true;
-                let item = list.item(cx, item_id, live_id!(EndOfChat)).unwrap();
-                item.draw_all(cx, &mut Scope::empty());
-            }
-
             if item_id < messages_count {
                 let chat_line_data = &messages[item_id];
 
@@ -874,6 +868,10 @@ impl ChatPanel {
                     chat_line_item.set_actions_enabled(cx, true);
                 }
 
+                item.draw_all(cx, &mut Scope::empty());
+            } else {
+                self.portal_list_end_reached = true;
+                let item = list.item(cx, item_id, live_id!(EndOfChat)).unwrap();
                 item.draw_all(cx, &mut Scope::empty());
             }
         }


### PR DESCRIPTION
# Problem

When you try to scroll further than the maximum possible amount, the jump to bottom button flickers.


https://github.com/moxin-org/moxin/assets/7684329/01148994-fe77-4947-b8bf-e0b84f7edc9f



# Changes

Detect if the end of the list has been reached in a different way. By telling the portal list to render one more item, and when the portal list renders that, flag that the portal list reached the end.