### PR TITLE
[Backend] bump wasmedge version to 0.14.0 for support windows

### DIFF
--- a/moxin-backend/Cargo.toml
+++ b/moxin-backend/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 moxin-protocol = { path = "../moxin-protocol" }
 chrono = "0.4"
-wasmedge-sdk = { version = "=0.13.5-newapi", default-features = false, features = [
+wasmedge-sdk = { version = "0.14.0", default-features = false, features = [
     "wasi_nn",
 ] }
 log = "0.4.21"

--- a/moxin-backend/src/backend_impls/chat_ui.rs
+++ b/moxin-backend/src/backend_impls/chat_ui.rs
@@ -240,7 +240,7 @@ fn get_input(
 
         Ok(vec![WasmValue::from_i32(n as i32)])
     } else {
-        Err(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Err(CoreError::Execution(CoreExecutionError::FuncSigMismatch))
     }
 }
 
@@ -274,7 +274,7 @@ fn push_token(
 
         Ok(vec![WasmValue::from_i32(if r { 0 } else { -1 })])
     } else {
-        Err(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Err(CoreError::Execution(CoreExecutionError::FuncSigMismatch))
     }
 }
 
@@ -299,7 +299,7 @@ fn return_token_error(
 
         Ok(vec![])
     } else {
-        Err(CoreError::Execution(CoreExecutionError::FuncTypeMismatch))
+        Err(CoreError::Execution(CoreExecutionError::FuncSigMismatch))
     }
 }
 

--- a/moxin-runner/src/main.rs
+++ b/moxin-runner/src/main.rs
@@ -237,6 +237,7 @@ fn install_wasmedge<P: AsRef<Path>>(install_path: P) -> Result<P, std::io::Error
     let bash_cmd = Command::new("bash")
         .arg("-s")
         .arg("--")
+        .arg("--version=0.14.0")
         .arg(&format!("--path={}", install_path.as_ref().display()))
         // The default `/tmp/` dir used in `install_v2.sh` isn't always accessible to bundled apps.
         .arg(&format!("--tmpdir={}", temp_dir.display()))


### PR DESCRIPTION
In Wasmedge 0.13.5, there is a bug in the plugins mechanism on Windows, so Moxin needs to upgrade to Wasmedge 0.14.0 to support Windows.


When build on Windows, you may encounter the following error. This is because `wasmedge-sys` use `bindgen`, which requires clang. To resolve this error, you need to download LLVM and specify the environment variable `LIBCLANG_PATH`.
```
--- stderr
  thread 'main' panicked at G:\.cargo\registry\src\index.crates.io-6f17d22bba15001f\bindgen-0.69.4\lib.rs:622:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['clang.dll', 'libclang.dll'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
```
It is only needed when running the build.rs script, so it only exists during the compilation phase.