### PR TITLE
Fix/increase context size

### DIFF
--- a/moxin-backend/src/backend_impls/api_server.rs
+++ b/moxin-backend/src/backend_impls/api_server.rs
@@ -45,11 +45,8 @@ fn create_wasi(
         moxin_protocol::protocol::GPULayers::Max => None,
     };
 
-    let batch_size = if load_model.n_batch > 0 {
-        Some(load_model.n_batch.to_string())
-    } else {
-        None
-    };
+    // Set n_batch to a fixed value of 128.
+    let batch_size = Some(format!("128"));
 
     let mut prompt_template = load_model.prompt_template.clone();
     if prompt_template.is_none() && !file.prompt_template.is_empty() {

--- a/moxin-backend/src/backend_impls/api_server.rs
+++ b/moxin-backend/src/backend_impls/api_server.rs
@@ -34,11 +34,8 @@ fn create_wasi(
     file: &DownloadedFile,
     load_model: &LoadModelOptions,
 ) -> wasmedge_sdk::WasmEdgeResult<WasiModule> {
-    let ctx_size = if load_model.n_ctx > 0 {
-        Some(load_model.n_ctx.to_string())
-    } else {
-        None
-    };
+    // use model metadata context size
+    let ctx_size = Some(format!("{}", file.context_size));
 
     let n_gpu_layers = match load_model.gpu_layers {
         moxin_protocol::protocol::GPULayers::Specific(n) => Some(n.to_string()),

--- a/moxin-backend/src/backend_impls/mod.rs
+++ b/moxin-backend/src/backend_impls/mod.rs
@@ -525,6 +525,7 @@ impl<Model: BackendModel + Send + 'static> BackendImpl<Model> {
                             quantization: remote_file.quantization,
                             prompt_template: remote_model.prompt_template,
                             reverse_prompt: remote_model.reverse_prompt,
+                            context_size:remote_model.context_size,
                             downloaded: false,
                             file_size: 0,
                             download_dir: self.models_dir.to_string_lossy().to_string(),

--- a/moxin-backend/src/store/remote.rs
+++ b/moxin-backend/src/store/remote.rs
@@ -6,10 +6,10 @@ use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Utc};
-use tokio::time::timeout;
-use std::time::Duration;
 use moxin_protocol::data::Model;
 use moxin_protocol::protocol::FileDownloadResponse;
+use std::time::Duration;
+use tokio::time::timeout;
 
 use crate::backend_impls::DownloadControlCommand;
 
@@ -42,6 +42,7 @@ pub struct RemoteModel {
     pub files: Vec<RemoteFile>,
     pub prompt_template: String,
     pub reverse_prompt: String,
+    pub context_size: u64,
     pub author: Author,
     pub like_count: u32,
     pub download_count: u32,
@@ -203,7 +204,7 @@ async fn download_file<P: AsRef<Path>>(
                             Err(_) => {}
                         }
                     }
-                },
+                }
                 None => {
                     // Download is complete
                     break;


### PR DESCRIPTION
*  `batch_size` is fixed to 128
* Use the value from model metadata for `ctx_size`.

Since ctx_size was not stored previously, if you are using an old data.sqlite file, it will use the default value of 1024. To check this logic, you can redownload the model or delete data.sqlite.
