### PR TITLE
[BackEnd] remove wasi_logging plugin

### DIFF
--- a/moxin-backend/src/backend_impls/api_server.rs
+++ b/moxin-backend/src/backend_impls/api_server.rs
@@ -97,15 +97,6 @@ pub fn run_wasm_by_downloaded_file(
     let mut wasi_nn = wasmedge_sdk::plugin::PluginManager::load_plugin_wasi_nn().unwrap();
     instances.insert(wasi_nn.name().unwrap(), &mut wasi_nn);
 
-    let mut wasi_logger = wasmedge_sdk::plugin::PluginManager::create_plugin_instance(
-        "wasi_logging",
-        "wasi:logging/logging",
-    );
-
-    if let Ok(wasi_logger) = &mut wasi_logger {
-        instances.insert(wasi_logger.name().unwrap(), wasi_logger);
-    }
-
     let store = Store::new(None, instances).unwrap();
     let mut vm = Vm::new(store);
     vm.register_module(None, wasm_module.clone()).unwrap();


### PR DESCRIPTION
fix https://github.com/moxin-org/moxin/issues/158
Because wasi-logging has some bug, let’s just remove it; it’s not actually serving any purpose now.