### PR TITLE
Make CI builds faster: debug builds, better powershell downloads

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -93,9 +93,10 @@ jobs:
 
       - name: Download WasmEdge
         run: |
+          $ProgressPreference = 'SilentlyContinue'
           Invoke-WebRequest -Uri "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-0.14.0-windows.zip" -OutFile "WasmEdge-0.14.0-windows.zip"
           Expand-Archive -LiteralPath "WasmEdge-0.14.0-windows.zip" -DestinationPath ${{ github.workspace }}
-          tree ${{ github.workspace }}\WasmEdge
+          tree /F ${{ github.workspace }}\WasmEdge
 
       - name: Set up Windows 10 SDK
         uses: GuillaumeFalourd/setup-windows10-sdk-action@v1.11

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -110,4 +110,4 @@ jobs:
 
       - name: Test Build
         run: |
-          cargo build --release
+          cargo build


### PR DESCRIPTION
powershell's `Invoke-WebRequest` is like... comically, laughably bad, and this makes it much much faster to download files.

Building in debug mode plus the above reduces CI time by about 30%.