### PR TITLE
Set MSRV to 1.79, as required by `cargo-packager`.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        rust: [1.79, 1.78, 1.77]
+        rust: [1.79]
     env:
       LD_LIBRARY_PATH: ~\.wasmedge\lib
 
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-14, macos-13]
-        rust: [1.79, 1.78, 1.77]
+        rust: [1.79]
 
     steps:
       - name: Checkout sources
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        rust: [1.79, 1.78, 1.77]
+        rust: [1.79]
     env:
       WASMEDGE_DIR: ${{ github.workspace }}\WasmEdge-0.14.0-Windows
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = [
 name = "moxin"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.79" ## required by cargo-packager
 description = "Desktop app for downloading and chatting with AI LLMs"
 
 ## Rename the binary to `_moxin_app` to avoid naming conflicts

--- a/README.md
+++ b/README.md
@@ -14,29 +14,32 @@ The following table shows which host systems can currently be used to build Moxi
 
 First, [install Rust](https://www.rust-lang.org/tools/install).
 
-Then, install the required WasmEdge WASM runtime:
-
-```sh
-curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.0
-
-source $HOME/.wasmedge/env
-```
-
 Obtain the source code from this repository:
 ```sh
 git clone https://github.com/moxin-org/moxin.git
 ```
 
 ### macOS
+Install the required WasmEdge WASM runtime:
+```sh
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.0
 
-Then, on a standard desktop platform (macOS), simply run:
+source $HOME/.wasmedge/env
+```
 
+Then use `cargo` to build and run Moxin:
 ```sh
 cd moxin
-cargo run
+cargo run --release
 ```
 
 ### Linux
+Install the required WasmEdge WASM runtime:
+```sh
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install_v2.sh | bash -s -- --version=0.14.0
+
+source $HOME/.wasmedge/env
+```
 
 To build Moxin on Linux, you must install the following dependencies:
 `openssl`, `clang`/`libclang`, `binfmt`, `Xcursor`/`X11`, `asound`/`pulse`.
@@ -47,11 +50,10 @@ sudo apt-get update
 sudo apt-get install libssl-dev pkg-config llvm clang libclang-dev binfmt-support libxcursor-dev libx11-dev libasound2-dev libpulse-dev
 ```
 
-Then, run:
-
+Then use `cargo` to build and run Moxin:
 ```sh
 cd moxin
-cargo run
+cargo run --release
 ```
 
 ## Windows (Windows 10 or higher)
@@ -92,21 +94,21 @@ cargo run
     ```powershell
     $env:WASMEDGE_DIR="$home\WasmEdge-0.14.0-Windows\"
     $env:WASMEDGE_PLUGIN_PATH="$home\WasmEdge-0.14.0-Windows\"
-    cargo run
+    cargo run --release
     ```
 
     In Windows `cmd`, you can do this like so:
     ```batch
     set WASMEDGE_DIR=%homedrive%%homepath%\WasmEdge-0.14.0-Windows
     set WASMEDGE_PLUGIN_PATH=%homedrive%%homepath%\WasmEdge-0.14.0-Windows
-    cargo run
+    cargo run --release
     ```
 
     In a Unix-like shell on Windows (e.g., GitBash, cygwin, msys2, WSL/WSL2):
     ```sh
     WASMEDGE_DIR=$HOME/WasmEdge-0.14.0-Windows \
     WASMEDGE_PLUGIN_PATH=$HOME/WasmEdge-0.14.0-Windows \
-    cargo run
+    cargo run --release
     ```
 
 

--- a/packaging/before-packaging-command/Cargo.toml
+++ b/packaging/before-packaging-command/Cargo.toml
@@ -2,6 +2,7 @@
 name = "before-packaging-command"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.79" ## required by cargo-packager
 description = "A small Rust program that is run by cargo-packager's 'before packaging' commands."
 
 [dependencies]


### PR DESCRIPTION
Update README instructions to be more clear about the procedures for installing WasmEdge on different host OSes