### PR TITLE
moxin-runner: on Windows, support WasmEdge no-avx WASI-nn plugin (release b3499)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,8 +1945,7 @@ checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 [[package]]
 name = "powershell_script"
 version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef8336090917f3d3a044256bc0e5c51d5420e5d09dfa1df4868083c5231a454"
+source = "git+https://github.com/project-robius/powershell-script.git?branch=accept_args#38fecaab261e70acc3358b6a913a9d05cdff28e0"
 
 [[package]]
 name = "ppv-lite86"

--- a/moxin-runner/Cargo.toml
+++ b/moxin-runner/Cargo.toml
@@ -9,7 +9,7 @@ directories = "5.0.1"
 
 [target.'cfg(windows)'.dependencies]
 ## For running a powershell script, which downloads and extracts/installs WasmEdge
-powershell_script = "1.1.0"
+powershell_script = { git = "https://github.com/project-robius/powershell-script.git", branch = "accept_args" }
 ## For showing a dialog box modal when the CPU is unsupported.
 windows-sys = { version = "0.52", features = ["Win32_UI_WindowsAndMessaging", "Win32_Foundation"] }
 

--- a/moxin-runner/src/powershell_install_wasmedge.ps1
+++ b/moxin-runner/src/powershell_install_wasmedge.ps1
@@ -2,6 +2,6 @@ $ProgressPreference = 'SilentlyContinue' ## makes downloads much faster
 Invoke-WebRequest -Uri "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-0.14.0-windows.zip" -OutFile "$env:TEMP\WasmEdge-0.14.0-windows.zip"
 Expand-Archive -Force -Path "$env:TEMP\WasmEdge-0.14.0-windows.zip" -DestinationPath $home
 
-Invoke-WebRequest -Uri "https://github.com/WasmEdge/WasmEdge/releases/download/0.14.0/WasmEdge-plugin-wasi_nn-ggml-0.14.0-windows_x86_64.zip" -OutFile "$env:TEMP\WasmEdge-plugin-wasi_nn-ggml-0.14.0-windows_x86_64.zip"
+Invoke-WebRequest -Uri "$args[0]" -OutFile "$env:TEMP\WasmEdge-plugin-wasi_nn-ggml-0.14.0-windows_x86_64.zip"
 Expand-Archive -Force -Path "$env:TEMP\WasmEdge-plugin-wasi_nn-ggml-0.14.0-windows_x86_64.zip" -DestinationPath "$home\WasmEdge-0.14.0-Windows"
 $ProgressPreference = 'Continue' ## restore default progress bars


### PR DESCRIPTION
WasmEdge recently released a version of the WASI-nn plugin that does not require AVX, but does require SSE4.2 or SSE4a. See here: <https://github.com/second-state/WASI-NN-GGML-PLUGIN-REGISTRY/releases/tag/b3499>

This PR supports falling back to the non-AVX plugin version on Windows, if the current CPU is detected to not support AVX512f.