### PR TITLE
Fix intermittent issue with model card title and description labels

### DIFF
--- a/src/landing/model_card.rs
+++ b/src/landing/model_card.rs
@@ -257,7 +257,7 @@ live_design! {
                 height: Fit,
                 padding: {bottom: 20}
 
-                model_name = <Label> {
+                modal_model_name = <Label> {
                     draw_text: {
                         text_style: <BOLD_FONT>{font_size: 16},
                         color: #000
@@ -278,7 +278,7 @@ live_design! {
                     }
                     text: "Model Description"
                 }
-                model_summary = <Label> {
+                modal_model_summary = <Label> {
                     width: Fill,
                     draw_text:{
                         text_style: <REGULAR_FONT>{font_size: 9},
@@ -433,10 +433,10 @@ impl Widget for ModelCardViewAllModal {
         let model = &scope.data.get::<ModelWithDownloadInfo>().unwrap();
 
         let name = &model.name;
-        self.label(id!(model_name)).set_text(name);
+        self.label(id!(modal_model_name)).set_text(name);
 
         let summary = &model.summary;
-        self.label(id!(model_summary)).set_text(summary);
+        self.label(id!(modal_model_summary)).set_text(summary);
 
         self.view
             .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }))


### PR DESCRIPTION
Fixes #204 

There was an issue where the title or description of some models in the main listing were not visible. The root problem was we were using similar identifiers for the title and description labels in `ModelCard` and `ModelCardViewAllModal` widgets (which is a nested view under the model card view).

The solution is to remove the ambiguity by providing unique identifiers for the labels into the modal widget, so the widget lookup for the labels is what we expect in each case.