### PR TITLE
After clicking on "Chat with Model", set keyboard focus to the Chat panel's prompt

### DIFF
--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -658,6 +658,8 @@ impl ChatPanel {
     ) {
         let prompt_input = self.text_input(id!(main_prompt_input.prompt));
 
+        prompt_input.set_key_focus(cx);
+
         let enabled = match mode {
             PromptInputMode::Enabled => !prompt_input.text().is_empty(),
             PromptInputMode::Disabled => false,


### PR DESCRIPTION
Addresses #203
While handling this issue, I also modified the code in Makepad that Moxin depends on.
[pr](https://github.com/jmbejar/makepad/pull/8)