### PR TITLE
Fix Chat section text inputs focus issues

### DIFF
--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -1,4 +1,4 @@
-use super::chat_history_card::ChatHistoryCardWidgetRefExt;
+use super::chat_history_card::{ChatHistoryCardAction, ChatHistoryCardWidgetRefExt};
 use crate::data::store::Store;
 use makepad_widgets::*;
 
@@ -122,6 +122,15 @@ impl WidgetMatchEvent for ChatHistory {
 
         if self.button(id!(new_chat_button)).clicked(&actions) {
             store.chats.create_empty_chat();
+
+            // Make sure text input is focused and other necessary setup happens.
+            let widget_uid = self.widget_uid();
+            cx.widget_action(
+                widget_uid,
+                &scope.path,
+                ChatHistoryCardAction::ChatSelected,
+            );
+
             self.redraw(cx);
         }
 

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -339,7 +339,7 @@ impl WidgetMatchEvent for ChatHistoryCard {
                 cx.widget_action(
                     widget_uid,
                     &scope.path,
-                    ChatHistoryCardAction::ChatSelected(self.chat_id),
+                    ChatHistoryCardAction::ChatSelected,
                 );
                 let store = scope.data.get_mut::<Store>().unwrap();
                 store.chats.set_current_chat(self.chat_id);
@@ -475,7 +475,7 @@ impl ChatHistoryCardRef {
 #[derive(Clone, DefaultNone, Eq, Hash, PartialEq, Debug)]
 pub enum ChatHistoryCardAction {
     None,
-    ChatSelected(ChatID),
+    ChatSelected,
     ActivateTitleEdition(ChatID),
     MenuClosed(ChatID),
     DeleteChatOptionSelected(ChatID),

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -456,6 +456,9 @@ pub struct ChatPanel {
 
     #[rust]
     portal_list_end_reached: bool,
+
+    #[rust(false)]
+    focus_on_prompt_input_pending: bool,
 }
 
 impl Widget for ChatPanel {
@@ -486,6 +489,17 @@ impl Widget for ChatPanel {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         self.update_view(cx, scope);
 
+        // We need to make sure we're drawing this widget in order to focus on the prompt input
+        // Otherwise, when navigating from another section this command would happen before the widget is drawn
+        // (not having any effect).
+        if self.focus_on_prompt_input_pending {
+            self.focus_on_prompt_input_pending = false;
+            let prompt_input = self.text_input(id!(main_prompt_input.prompt));
+            prompt_input.set_text("");
+            prompt_input.set_cursor(0, 0);
+            prompt_input.set_key_focus(cx);
+        }
+
         while let Some(view_item) = self.view.draw_walk(cx, scope, walk).step() {
             if let Some(mut list) = view_item.as_portal_list().borrow_mut() {
                 self.draw_messages(cx, scope, &mut list);
@@ -505,8 +519,9 @@ impl WidgetMatchEvent for ChatPanel {
             .iter()
             .filter_map(|action| action.as_widget_action())
         {
-            if let ChatHistoryCardAction::ChatSelected(_) = action.cast() {
+            if let ChatHistoryCardAction::ChatSelected = action.cast() {
                 self.reset_scroll_messages(&store);
+                self.focus_on_prompt_input_pending = true;
                 self.redraw(cx);
             }
 
@@ -517,6 +532,8 @@ impl WidgetMatchEvent for ChatPanel {
                     chat.borrow_mut().last_used_file_id = Some(downloaded_file.file.id.clone());
                     chat.borrow().save();
                 }
+
+                self.focus_on_prompt_input_pending = true;
                 self.redraw(cx)
             }
 
@@ -524,6 +541,7 @@ impl WidgetMatchEvent for ChatPanel {
                 ChatAction::Start(file_id) => {
                     if let Some(file) = store.downloads.get_file(&file_id) {
                         store.chats.create_empty_chat_and_load_file(file);
+                        self.focus_on_prompt_input_pending = true;
                     }
                 }
                 _ => {}
@@ -657,8 +675,6 @@ impl ChatPanel {
         button: PromptInputButton,
     ) {
         let prompt_input = self.text_input(id!(main_prompt_input.prompt));
-
-        prompt_input.set_key_focus(cx);
 
         let enabled = match mode {
             PromptInputMode::Enabled => !prompt_input.text().is_empty(),


### PR DESCRIPTION
A problem was introduced in #236 where it is impossible to write in several text inputs in the Chat section interface.
This was happening because the `key_focus` was always set to the main prompt input.

Here we reimplemented the desired behavior (autofocus the prompt input when a new chat is created or we switch between chats) without messing with other text inputs (such as System Prompt, Stop, inline edition of chat messages, etc)