### PR TITLE
Fix problem with click events in popup notifications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -237,7 +237,7 @@ impl MatchEvent for App {
                 DownloadNotificationPopupAction::ActionLinkClicked
                     | DownloadNotificationPopupAction::CloseButtonClicked
             ) {
-                self.ui.popup_notification(id!(popup_notification)).open(cx);
+                self.ui.popup_notification(id!(popup_notification)).close(cx);
             }
         }
     }

--- a/src/shared/popup_notification.rs
+++ b/src/shared/popup_notification.rs
@@ -22,6 +22,9 @@ live_design! {
             flow: Overlay
             width: Fit
             height: Fit
+
+            cursor: Default
+            capture_overload: true
         }
     }
 }


### PR DESCRIPTION
There were two issues with popup notifications displayed when models are downloaded:

* The popup was refusing to be dismissed (e.g. close button not working)
* The user could interact with the dropdown that sits under this floating element (in Explorer section), when it was not the expected thing to happen.

Both issues are addressed in this PR.