### PR TITLE
Reset edition state when chat history card is re-used

### DIFF
--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -362,7 +362,10 @@ impl WidgetMatchEvent for ChatHistoryCard {
 
 impl ChatHistoryCard {
     pub fn set_chat_id(&mut self, id: ChatID) {
-        self.chat_id = id;
+        if id != self.chat_id {
+            self.chat_id = id;
+            self.title_edition_state = TitleState::Editable;
+        }
     }
 
     fn set_title_text(&mut self, text: &str) {


### PR DESCRIPTION
Fixes #185

This cancels the chat edition whenever a history card's `chat_id` is updated, so that deleting a chat from the history does not cause the editing state to be "moved" into another chat's card.

Whenever a chat is removed, the `ChatHistoryCard` widget that was created for that chat, is re-used for the next one on the list. It's state must be updated accordingly. This changes just reset the state back to default.