### PR TITLE
Vendor git2 deps on openssl and libssh to avoid packaging failures

### DIFF
--- a/moxin-backend/Cargo.toml
+++ b/moxin-backend/Cargo.toml
@@ -23,4 +23,4 @@ rusqlite = { version = "0.31.0", features = ["bundled"] }
 serde = "1.0.197"
 tokio = { version = "1", features = ["full"] }
 futures-util = "0.3.30"
-git2 = "0.19.0"
+git2 = { version = "0.19.0", features = ["vendored-libgit2", "vendored-openssl"] }


### PR DESCRIPTION
On macOS (at least, probably other platforms too), we cannot depend on system libraries that don't get packaged up with the app bundle. Previously we were handling this for `reqwest`, but a recent addition of a dependency on `git2` (which depends on `libgit2-sys`) caused packaged app bundles to fail to run on macOS.

PR-ing against main because this is a hotfix required for packaging correctness.