### PR TITLE
[Backend] fix model name

### DIFF
--- a/moxin-backend/src/backend_impls/api_server.rs
+++ b/moxin-backend/src/backend_impls/api_server.rs
@@ -88,10 +88,10 @@ fn create_wasi(
 
     let listen_addr = Some(format!("{listen_addr}"));
 
-    let mut module_alias = file.name.clone();
+    let mut module_alias = "moxin-chat".to_string();
     if embedding.is_some() {
         module_alias.push_str(",");
-        module_alias.push_str("embedding");
+        module_alias.push_str("moxin-embedding");
     }
     let mut args = vec![
         "llama-api-server",
@@ -276,7 +276,7 @@ impl BackendModel for LLamaEdgeApiServer {
     fn chat(
         &self,
         async_rt: &tokio::runtime::Runtime,
-        data: moxin_protocol::open_ai::ChatRequestData,
+        mut data: moxin_protocol::open_ai::ChatRequestData,
         tx: std::sync::mpsc::Sender<anyhow::Result<ChatResponse>>,
     ) -> bool {
         let is_stream = data.stream.unwrap_or(false);
@@ -285,6 +285,8 @@ impl BackendModel for LLamaEdgeApiServer {
             self.listen_addr.port()
         );
         let mut cancel = self.running_controller.subscribe();
+
+        data.model = "moxin-chat".to_string();
 
         async_rt.spawn(async move {
             let request_body = serde_json::to_string(&data).unwrap();

--- a/moxin-backend/src/backend_impls/mod.rs
+++ b/moxin-backend/src/backend_impls/mod.rs
@@ -720,7 +720,7 @@ pub fn nn_preload_file(
         .join(&file.name);
 
     let preloads = wasmedge_sdk::plugin::NNPreload::new(
-        file.name.clone(),
+        "moxin-chat",
         wasmedge_sdk::plugin::GraphEncoding::GGML,
         wasmedge_sdk::plugin::ExecutionTarget::AUTO,
         &file_path,
@@ -729,7 +729,7 @@ pub fn nn_preload_file(
     let mut preload_vec = vec![preloads];
     if let Some((embedding_path, _)) = embedding {
         let preloads = wasmedge_sdk::plugin::NNPreload::new(
-            "embedding".to_string(),
+            "moxin-embedding",
             wasmedge_sdk::plugin::GraphEncoding::GGML,
             wasmedge_sdk::plugin::ExecutionTarget::AUTO,
             &embedding_path,


### PR DESCRIPTION
* Fixed chat model name as "moxin-chat"
* Fixed embedding model name as "moxin-embedding"

The frontend doesn't need to change because I've already replaced the model name in the request on the backend