### PR TITLE
Fix visibility of markdown-formatted message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1471,7 +1471,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1479,7 +1479,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "ab_glyph_rasterizer",
  "fxhash",
@@ -1505,17 +1505,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "0.7.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-html"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -1534,7 +1534,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -1544,7 +1544,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "makepad-markdown"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-id",
 ]
@@ -1578,25 +1578,26 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
+ "makepad-live-id",
  "makepad-micro-serde-derive",
 ]
 
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -1604,12 +1605,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "makepad-platform"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "hilog-sys",
  "makepad-android-state",
@@ -1631,7 +1632,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -1646,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "0.5.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -1654,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "makepad-vector"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "resvg",
  "ttf-parser",
@@ -1663,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "0.4.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -1672,7 +1673,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "0.6.0"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -1686,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "makepad-windows"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "windows-core 0.51.1",
  "windows-targets 0.48.5",
@@ -1695,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1703,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-inflate"
 version = "0.2.54"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "simd-adler32",
 ]
@@ -1711,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -1719,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.2.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "makepad-zune-core",
  "makepad-zune-inflate",
@@ -3150,7 +3151,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 
 [[package]]
 name = "typenum"
@@ -3577,7 +3578,7 @@ dependencies = [
 [[package]]
 name = "windows-core"
 version = "0.51.1"
-source = "git+https://github.com/makepad/makepad?branch=rik#8b52d23e1745e12ad93bd55b625ef616926c6f5e"
+source = "git+https://github.com/makepad/makepad?branch=rik#cdacc2ea6ab726dcb24a64a07f7f790d06d2c384"
 dependencies = [
  "windows-targets 0.48.5",
 ]

--- a/src/chat/chat_line.rs
+++ b/src/chat/chat_line.rs
@@ -61,6 +61,7 @@ live_design! {
         padding: 0,
         line_spacing: (LINE_SPACING),
         paragraph_spacing: 20.0,
+        font_color: #000,
         width: Fill, height: Fit,
         font_size: 10.0,
         draw_normal: {

--- a/src/chat/chat_panel.rs
+++ b/src/chat/chat_panel.rs
@@ -60,27 +60,28 @@ live_design! {
                     }
                     markdown_message_container = {
                         markdown_message = {
+                            font_color: #fff,
                             draw_normal: {
-                                color: (#fff),
+                                color: #fff,
                             }
                             draw_italic: {
-                                color: (#fff),
+                                color: #fff,
                             }
                             draw_bold: {
-                                color: (#fff),
+                                color: #fff,
                             }
                             draw_bold_italic: {
-                                color: (#fff),
+                                color: #fff,
                             }
                             draw_fixed: {
-                                color: (#fff),
+                                color: #fff,
                             }
                             draw_block: {
-                                line_color: (#fff)
-                                sep_color: (#12778a)
-                                quote_bg_color: (#12778a)
-                                quote_fg_color: (#106a7b)
-                                code_color: (#12778a)
+                                line_color: #fff
+                                sep_color: #12778a
+                                quote_bg_color: #12778a
+                                quote_fg_color: #106a7b
+                                code_color: #12778a
                             }
                         }
                     }


### PR DESCRIPTION
This PR bumps the Makepad version. Some adjustments were needed to avoid a visual problem that was very noticeable in markdown-formatted messages.

This screenshot demonstrates the font color issue (bumping to most recent Makepad version, without the other changes in this PR)
![image](https://github.com/user-attachments/assets/8f5340f6-dead-4717-98df-e5bec896780f)
