### PR TITLE
Add encrpyion to moly-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +621,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +643,17 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
 
 [[package]]
 name = "cssparser"
@@ -615,6 +689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "data-url"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +712,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -961,6 +1055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1139,15 @@ name = "hilog-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b570882b8450bb0c9edfc3e4bdd3bd298667d38cb15e5b5c67586a7fb78429a"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -1300,6 +1423,15 @@ checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1955,14 +2087,20 @@ dependencies = [
 name = "moly-sync"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "axum",
+ "base64",
  "env_logger",
+ "getrandom 0.2.16",
  "log",
  "moly-kit",
+ "pbkdf2",
  "rand 0.9.1",
  "reqwest",
+ "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tower-http 0.5.2",
 ]
@@ -2155,6 +2293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,6 +2341,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -2319,6 +2473,18 @@ name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2505,6 +2671,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -2911,6 +3080,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "204ea332803bd95a0b60388590d59cf6468ec9becf626e2451f1d26a1d972de4"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3358,6 +3538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3615,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,6 +3687,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/moly-sync/Cargo.toml
+++ b/moly-sync/Cargo.toml
@@ -7,9 +7,16 @@ edition = "2021"
 moly-kit = { path = "../moly-kit", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 log = "0.4"
 env_logger = "0.11"
+# Crypto dependencies for encryption
+aes-gcm = "0.10"
+pbkdf2 = "0.12"
+sha2 = "0.10"
+base64 = "0.22"
+getrandom = { version = "0.2", features = ["js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = "0.7"

--- a/moly-sync/src/crypto.rs
+++ b/moly-sync/src/crypto.rs
@@ -1,0 +1,164 @@
+use aes_gcm::{
+    aead::{Aead, KeyInit},
+    Aes256Gcm, Key, Nonce,
+};
+use anyhow::{Context, Result};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use pbkdf2::pbkdf2_hmac;
+use sha2::Sha256;
+
+const PBKDF2_ITERATIONS: u32 = 100_000;
+const SALT_SIZE: usize = 16;
+const NONCE_SIZE: usize = 12;
+
+/// Encrypted data format that includes salt, nonce, and ciphertext
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct EncryptedData {
+    /// Base64-encoded salt used for key derivation
+    pub salt: String,
+    /// Base64-encoded nonce used for encryption
+    pub nonce: String,
+    /// Base64-encoded encrypted data
+    pub data: String,
+}
+
+/// Derive an AES-256 key from a PIN and salt using PBKDF2
+fn derive_key(pin: &str, salt: &[u8]) -> [u8; 32] {
+    let mut key = [0u8; 32];
+    pbkdf2_hmac::<Sha256>(pin.as_bytes(), salt, PBKDF2_ITERATIONS, &mut key);
+    key
+}
+
+/// Encrypt JSON data using AES-256-GCM with a PIN-derived key
+///
+/// Returns base64-encoded JSON containing salt, nonce, and encrypted data
+pub fn encrypt_json(json_data: &str, pin: &str) -> Result<String> {
+    // Generate random salt and nonce
+    let mut salt = [0u8; SALT_SIZE];
+    let mut nonce_bytes = [0u8; NONCE_SIZE];
+
+    getrandom::getrandom(&mut salt)
+        .map_err(|e| anyhow::anyhow!("Failed to generate random salt: {}", e))?;
+    getrandom::getrandom(&mut nonce_bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to generate random nonce: {}", e))?;
+
+    // Derive key from PIN and salt
+    let key_bytes = derive_key(pin, &salt);
+    let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+    let cipher = Aes256Gcm::new(key);
+
+    // Create nonce
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    // Encrypt the JSON data
+    let ciphertext = cipher
+        .encrypt(nonce, json_data.as_bytes())
+        .map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;
+
+    // Create encrypted data structure
+    let encrypted_data = EncryptedData {
+        salt: BASE64.encode(&salt),
+        nonce: BASE64.encode(&nonce_bytes),
+        data: BASE64.encode(&ciphertext),
+    };
+
+    // Return as JSON string
+    serde_json::to_string(&encrypted_data).context("Failed to serialize encrypted data")
+}
+
+/// Decrypt JSON data using AES-256-GCM with a PIN-derived key
+///
+/// Takes base64-encoded JSON containing salt, nonce, and encrypted data
+/// Returns the original JSON string
+pub fn decrypt_json(encrypted_json: &str, pin: &str) -> Result<String> {
+    // Parse the encrypted data structure
+    let encrypted_data: EncryptedData =
+        serde_json::from_str(encrypted_json).context("Failed to parse encrypted data JSON")?;
+
+    // Decode base64 components
+    let salt = BASE64
+        .decode(&encrypted_data.salt)
+        .context("Failed to decode salt from base64")?;
+    let nonce_bytes = BASE64
+        .decode(&encrypted_data.nonce)
+        .context("Failed to decode nonce from base64")?;
+    let ciphertext = BASE64
+        .decode(&encrypted_data.data)
+        .context("Failed to decode ciphertext from base64")?;
+
+    // Validate sizes
+    if salt.len() != SALT_SIZE {
+        anyhow::bail!(
+            "Invalid salt size: expected {}, got {}",
+            SALT_SIZE,
+            salt.len()
+        );
+    }
+    if nonce_bytes.len() != NONCE_SIZE {
+        anyhow::bail!(
+            "Invalid nonce size: expected {}, got {}",
+            NONCE_SIZE,
+            nonce_bytes.len()
+        );
+    }
+
+    // Derive key from PIN and salt
+    let key_bytes = derive_key(pin, &salt);
+    let key = Key::<Aes256Gcm>::from_slice(&key_bytes);
+    let cipher = Aes256Gcm::new(key);
+
+    // Create nonce
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    // Decrypt the data
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext.as_ref())
+        .map_err(|e| anyhow::anyhow!("Decryption failed: {}", e))?;
+
+    // Convert back to string
+    String::from_utf8(plaintext).context("Decrypted data is not valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let original_data = r#"{"test": "data", "number": 42}"#;
+        let pin = "1234";
+
+        let encrypted = encrypt_json(original_data, pin).unwrap();
+        let decrypted = decrypt_json(&encrypted, pin).unwrap();
+
+        assert_eq!(original_data, decrypted);
+    }
+
+    #[test]
+    fn test_wrong_pin_fails() {
+        let original_data = r#"{"test": "data"}"#;
+        let pin = "1234";
+        let wrong_pin = "5678";
+
+        let encrypted = encrypt_json(original_data, pin).unwrap();
+        let result = decrypt_json(&encrypted, wrong_pin);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_different_encryptions_produce_different_results() {
+        let data = r#"{"test": "data"}"#;
+        let pin = "1234";
+
+        let encrypted1 = encrypt_json(data, pin).unwrap();
+        let encrypted2 = encrypt_json(data, pin).unwrap();
+
+        // Should be different due to random salt and nonce
+        assert_ne!(encrypted1, encrypted2);
+
+        // But both should decrypt to the same original data
+        assert_eq!(decrypt_json(&encrypted1, pin).unwrap(), data);
+        assert_eq!(decrypt_json(&encrypted2, pin).unwrap(), data);
+    }
+}

--- a/moly-sync/src/lib.rs
+++ b/moly-sync/src/lib.rs
@@ -1,7 +1,9 @@
 mod client;
+mod crypto;
 #[cfg(not(target_arch = "wasm32"))]
 mod server;
 
 pub use client::*;
+pub use crypto::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::*;

--- a/src/settings/sync_modal.rs
+++ b/src/settings/sync_modal.rs
@@ -6,7 +6,7 @@ use moly_kit::utils::asynchronous::spawn;
 use moly_sync::fetch_json;
 
 #[cfg(not(target_arch = "wasm32"))]
-use moly_sync::{ServerHandle, start_server_with_handle};
+use moly_sync::{ServerHandle, start_server};
 
 use crate::data::store::Store;
 
@@ -392,7 +392,7 @@ impl SyncModal {
         let ui = self.ui_runner();
         spawn(async move {
             // Start moly-sync server
-            let server_result = start_server_with_handle(json_file, None).await;
+            let server_result = start_server(json_file, None).await;
             match server_result {
                 Ok(server_handle) => {
                     let addr = server_handle.addr;


### PR DESCRIPTION
### Changes

- New crypto module (moly-sync/src/crypto.rs): AES-256-GCM encryption with PBKDF2 key derivation
- Server: Pre-encrypts preferences JSON using PIN before serving
- Client: Decrypts received data using PIN (works on native + WASM)
- Dependencies: Added wasm-compatible crypto crates (aes-gcm, pbkdf2, sha2, base64)