### PR TITLE
Implement search in model selector

### DIFF
--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -26,6 +26,7 @@ live_design! {
     use crate::chat::model_selector_loading::ModelSelectorLoading;
 
     ICON_DROP = dep("crate://self/resources/images/drop_icon.png")
+    ICON_SEARCH = dep("crate://self/resources/icons/search.svg")
 
     ModelSelectorButton = <View> {
         width: Fit,
@@ -112,6 +113,32 @@ live_design! {
             uniform shadow_color: #0002
             shadow_radius: 9.0,
             shadow_offset: vec2(0.0,-2.0)
+        }
+
+        search = <View> {
+            width: Fill, height: Fit,
+            show_bg: true,
+            padding: {top: 3, bottom: 3, left: 20, right: 20},
+            spacing: 4,
+            align: {x: 0.0, y: 0.5},
+            draw_bg: {
+                border_radius: 9.0,
+                border_color: #D0D5DD,
+                border_size: 1.0,
+                color: #fff,
+            }
+            <Icon> {
+                draw_icon: {
+                    svg_file: (ICON_SEARCH),
+                    fn get_color(self) -> vec4 { return #666; }
+                }
+                icon_walk: {width: 14, height: Fit}
+            }
+            input = <MolyTextInput> {
+                width: Fill, height: Fit,
+                empty_text: "Search models",
+                draw_text: { text_style:<REGULAR_FONT>{font_size: 11} }
+            }
         }
 
         list_container = <View> {
@@ -394,6 +421,15 @@ impl WidgetMatchEvent for ModelSelector {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let mut should_hide_options = false;
         for action in actions {
+            if let Some(text) = self
+                .text_input(id!(options.search.input))
+                .changed(actions)
+            {
+                self
+                    .model_selector_list(id!(list_container.list))
+                    .set_search_filter(cx, &text);
+            }
+
             match action.cast() {
                 ModelSelectorAction::BotSelected(chat_id, m) => {
                     if chat_id == self.chat_id {

--- a/src/chat/model_selector_list.rs
+++ b/src/chat/model_selector_list.rs
@@ -104,6 +104,9 @@ pub struct ModelSelectorList {
     total_height: Option<f64>,
 
     #[rust]
+    search_filter: String,
+
+    #[rust]
     chat_id: ChatID,
 }
 
@@ -184,6 +187,12 @@ impl ModelSelectorList {
         // Sort providers alphabetically by name
         providers.sort_by(|a, b| a.1.cmp(&b.1));
 
+        let terms = self
+            .search_filter
+            .split_whitespace()
+            .map(|s| s.to_ascii_lowercase())
+            .collect::<Vec<_>>();
+
         // Add models grouped by provider
         for (provider_url, provider_name, mut provider_bots) in providers {
             if provider_bots.is_empty() {
@@ -192,6 +201,25 @@ impl ModelSelectorList {
 
             // Sort models within each provider by name for consistent ordering
             provider_bots.sort_by(|a, b| a.name.cmp(&b.name));
+
+            let provider_bots: Vec<ProviderBot> = provider_bots
+                .into_iter()
+                .filter(|bot| {
+                    if terms.is_empty() {
+                        true
+                    } else {
+                        let name = bot.human_readable_name().to_ascii_lowercase();
+                        let id = bot.name.to_ascii_lowercase();
+                        terms
+                            .iter()
+                            .all(|t| name.contains(t) || id.contains(t))
+                    }
+                })
+                .collect();
+
+            if provider_bots.is_empty() {
+                continue;
+            }
 
             // Add provider section label
             let section_id = LiveId::from_str(&provider_url);
@@ -311,5 +339,13 @@ impl ModelSelectorListRef {
             return;
         };
         inner.chat_id = chat_id;
+    }
+
+    pub fn set_search_filter(&mut self, cx: &mut Cx, filter: &str) {
+        let Some(mut inner) = self.borrow_mut() else { return; };
+        inner.search_filter = filter.to_string();
+        inner.total_height = None;
+        inner.items.clear();
+        inner.redraw(cx);
     }
 }


### PR DESCRIPTION
## Summary
- add search icon constant and search bar UI to the model selector popup
- implement filtering in `ModelSelectorList` and expose `set_search_filter`
- watch search input changes and update the list

## Testing
- `cargo fmt --all -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo test --all-features` *(fails to build: linking with `cc` failed)*
- `cargo test --all-features --package moly-kit` *(fails to build: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852d6bd35548324b78689fdb081a4ec