### PR TITLE
Add MCP config to mobile layout

### DIFF
--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -232,7 +232,7 @@ impl ChatScreen {
         };
 
         let mut context: BotContext = multi_client.into();
-        let tool_manager = store.create_and_load_mcp_tool_manager(context.clone());
+        let tool_manager = store.create_and_load_mcp_tool_manager();
         context.set_tool_manager(tool_manager);
 
         store.bot_context = Some(context.clone());
@@ -243,7 +243,7 @@ impl ChatScreen {
 
         let ui = self.ui_runner();
         spawn(async move {
-            context.load().await;
+            let _ = context.load().await;
 
             ui.defer_with_redraw(move |me, cx, scope| {
                 me.creating_bot_context = false;

--- a/src/chat/chat_screen_mobile.rs
+++ b/src/chat/chat_screen_mobile.rs
@@ -1,4 +1,5 @@
 use makepad_widgets::*;
+use moly_kit::widgets::moly_modal::MolyModalWidgetExt;
 
 live_design! {
     use link::theme::*;
@@ -11,11 +12,58 @@ live_design! {
     use crate::chat::chats_deck::ChatsDeck;
     use crate::settings::providers_screen::ProvidersScreen;
     use crate::settings::provider_view::ProviderView;
+    use crate::mcp::mcp_screen::McpScreen;
+    use moly_kit::widgets::moly_modal::*;
 
     ICON_NEW_CHAT = dep("crate://self/resources/icons/new_chat.svg")
 
-    HEADER_HEIGHT = 100
+    SettingsMenu = <MolyModal> {
+        align: {x: 0.0, y: 0.0}
+        bg_view: {
+            visible: false
+        }
+        content: <RoundedView> {
+            show_bg: true
+            draw_bg: {border_radius: 5, color: #f}
+            width: 150, height: Fit
+            align: {x: 0.5, y: 0.5}
+            flow: Down
+            spacing: 10
+            padding: {left: 10, right: 10, top: 20, bottom: 20}
+            go_to_providers = <View> {
+                align: {x: 0.5, y: 0.5}
+                width: Fill, height: Fit
+                cursor: Hand
+                <Label> {
+                    text: "Providers"
+                    draw_text: {
+                        color: #x0
+                    }
+                }
+            }
 
+            separator =<View> {
+                width: Fill, height: 0.5
+                show_bg: true
+                draw_bg: {color: #d3d3d3}
+                margin: {left: 10, right: 10}
+            }
+
+            go_to_mcp = <View> {
+                align: {x: 0.5, y: 0.5}
+                width: Fill, height: Fit
+                cursor: Hand
+                <Label> {
+                    text: "MCP Servers"
+                    draw_text: {
+                        color: #x0
+                    }
+                }
+            }
+        }
+    }
+
+    HEADER_HEIGHT = 100
     MolyNavigationView = <StackNavigationView> {
         width: Fill, height: Fill
         draw_bg: { color: (MAIN_BG_COLOR) }
@@ -98,6 +146,7 @@ live_design! {
                                 }
                             }
                         }
+                        settings_menu = <SettingsMenu> {}
                     }
                 }
                 body = {
@@ -131,6 +180,24 @@ live_design! {
                                 }
                             }
                         }
+                    }
+                }
+            }
+
+            mcp_navigation_view = <MolyNavigationView> {
+                header = {
+                    content = {
+                        title_container = {
+                            title = {
+                                text: "MCP Servers"
+                            }
+                        }
+                    }
+                }
+                body = {
+                    mcp_screen = <McpScreen> {
+                        width: Fill, height: Fill
+                        header = { visible: false }
                     }
                 }
             }
@@ -196,12 +263,49 @@ impl WidgetMatchEvent for ChatScreenMobile {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let stack_navigation = self.stack_navigation(id!(navigation));
         stack_navigation.handle_stack_view_actions(cx, actions);
+
+        // Menu Toggle
         if let Some(_evt) = self.view(id!(menu_toggle)).finger_down(actions) {
             stack_navigation.push(cx, live_id!(history_navigation_view));
         }
 
+        let modal = self.moly_modal(id!(settings_menu));
+
+        // Settings Menu
         if let Some(_evt) = self.view(id!(settings_button)).finger_down(actions) {
+            // TODO: Ideally we should use the settings_button position but for some reason is always coming back fixed at 100.0
+            let parent_view_width = self
+                .stack_navigation_view(id!(history_navigation_view))
+                .area()
+                .rect(cx)
+                .size
+                .x;
+
+            let button_rect = self.view(id!(settings_button)).area().rect(cx);
+            let coords = dvec2(
+                parent_view_width - 170.0,
+                button_rect.pos.y + button_rect.size.y,
+            );
+
+            modal.apply_over(
+                cx,
+                live! {
+                    content: { margin: { left: (coords.x), top: (coords.y) }}
+                },
+            );
+            modal.open(cx);
+        }
+
+        // Go to Providers
+        if let Some(_evt) = self.view(id!(go_to_providers)).finger_down(actions) {
+            modal.close(cx);
             stack_navigation.push(cx, live_id!(providers_navigation_view));
+        }
+
+        // Go to MCP Servers
+        if let Some(_evt) = self.view(id!(go_to_mcp)).finger_down(actions) {
+            modal.close(cx);
+            stack_navigation.push(cx, live_id!(mcp_navigation_view));
         }
     }
 }

--- a/src/data/preferences.rs
+++ b/src/data/preferences.rs
@@ -133,14 +133,26 @@ impl Preferences {
     ///
     /// If merge is true, the provider preferences will be extended with the new ones,
     /// otherwise, the existing preferences will be replaced.
-    pub fn import_from_json(&mut self, json: &str, merge: bool) -> Result<(), serde_json::Error> {
+    ///
+    /// If include_mcp_servers is true, the MCP servers will be included in the import, replacing the existing ones.
+    pub fn import_from_json(
+        &mut self,
+        json: &str,
+        merge: bool,
+        include_mcp_servers: bool,
+    ) -> Result<(), serde_json::Error> {
         let preferences = serde_json::from_str::<Preferences>(json)?;
         if merge {
             self.providers_preferences
-                .extend(preferences.providers_preferences);
+                .extend(preferences.providers_preferences.clone());
         } else {
-            *self = preferences;
+            self.providers_preferences = preferences.providers_preferences.clone();
         }
+
+        if include_mcp_servers {
+            self.mcp_servers_config = preferences.mcp_servers_config;
+        }
+
         self.save();
         Ok(())
     }

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -469,7 +469,7 @@ impl Store {
 
     /// Creates a new MCP tool manager and loads servers asynchronously
     /// Returns the manager immediately, loading happens in the background
-    pub fn create_and_load_mcp_tool_manager(&self, _context: BotContext) -> McpManagerClient {
+    pub fn create_and_load_mcp_tool_manager(&self) -> McpManagerClient {
         let tool_manager = McpManagerClient::new();
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -499,17 +499,16 @@ impl Store {
 
     pub fn update_mcp_servers_from_json(&mut self, json: &str) -> Result<(), serde_json::Error> {
         self.preferences.update_mcp_servers_from_json(json)?;
-
-        // Update the tool manager in the existing bot context
-        if let Some(ref bot_context) = self.bot_context {
-            let context_clone = bot_context.clone();
-            let new_tool_manager = self.create_and_load_mcp_tool_manager(context_clone);
-            // Update the bot_context after the creation
-            if let Some(ref mut bot_context_mut) = self.bot_context {
-                bot_context_mut.replace_tool_manager(new_tool_manager);
-            }
-        }
+        self.update_mcp_tool_manager();
 
         Ok(())
+    }
+
+    pub fn update_mcp_tool_manager(&mut self) {
+        let new_tool_manager = self.create_and_load_mcp_tool_manager();
+        // Update the bot_context after the creation
+        if let Some(ref mut bot_context_mut) = self.bot_context {
+            bot_context_mut.replace_tool_manager(new_tool_manager);
+        }
     }
 }

--- a/src/mcp/mcp_screen.rs
+++ b/src/mcp/mcp_screen.rs
@@ -11,14 +11,6 @@ live_design! {
 
     use crate::mcp::mcp_servers::McpServers;
 
-    HorizontalSeparator = <RoundedView> {
-        width: 2, height: Fill
-        show_bg: true
-        draw_bg: {
-            color: #d3d3d3
-        }
-    }
-
     pub McpScreen = {{McpScreen}} {
         width: Fill, height: Fill
         spacing: 20

--- a/src/settings/providers.rs
+++ b/src/settings/providers.rs
@@ -25,7 +25,6 @@ live_design! {
     ICON_TRASH = dep("crate://self/resources/images/trash_icon.png")
     ICON_REMOTE = dep("crate://self/resources/images/globe_icon.png")
     ICON_LOCAL = dep("crate://self/resources/images/laptop_icon.png")
-    ICON_SETTINGS = dep("crate://self/resources/images/settings_icon.png")
 
     ICON_SUCCESS = dep("crate://self/resources/images/circle_check_icon.png")
     ICON_LOADER = dep("crate://self/resources/images/loader_icon.png")


### PR DESCRIPTION
Adds MCP config to the mobile layout

### Changes
- Adds MCP config to the mobile navigation through a new popup upon clicking settings

https://github.com/user-attachments/assets/80cd29e7-2ac4-4e6d-92c7-096ee1399886

- Adds MCP config import as an option on settings sync import

<img width="463" height="610" alt="image" src="https://github.com/user-attachments/assets/8efe31dc-e161-490f-8672-fc9dc22ce016" />

- For mobile we use TextInput for editing instead of the Makepad code editor which has limited support in mobile (some issues around IME)

- Mobile only supports HTTP/SSE servers, for now I only added a text clarifying this, later on we'll check and remove stdio servers from the config upon save.