### PR TITLE
Bump makepad and update live id macro usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "ab_glyph_rasterizer"
 version = "0.1.8"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "ab_glyph_rasterizer"
@@ -2320,7 +2320,7 @@ dependencies = [
 [[package]]
 name = "makepad-code-editor"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-widgets",
 ]
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-live"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2337,7 +2337,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "makepad-derive-widget"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-proc-macro",
@@ -2354,7 +2354,7 @@ dependencies = [
 [[package]]
 name = "makepad-draw"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "ab_glyph_rasterizer 0.1.8",
  "fxhash",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold"
 version = "1.0.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-platform",
 ]
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-bold-2"
 version = "1.0.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-platform",
 ]
@@ -2389,7 +2389,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular"
 version = "1.0.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-platform",
 ]
@@ -2397,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-chinese-regular-2"
 version = "1.0.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-platform",
 ]
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "makepad-fonts-emoji"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-platform",
 ]
@@ -2413,17 +2413,17 @@ dependencies = [
 [[package]]
 name = "makepad-futures"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-futures-legacy"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-html"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id",
 ]
@@ -2431,23 +2431,7 @@ dependencies = [
 [[package]]
 name = "makepad-http"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
-
-[[package]]
-name = "makepad-id"
-version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
-dependencies = [
- "makepad-id-derive",
-]
-
-[[package]]
-name = "makepad-id-derive"
-version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
-dependencies = [
- "makepad-micro-proc-macro",
-]
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-jni-sys"
@@ -2458,7 +2442,7 @@ checksum = "9775cbec5fa0647500c3e5de7c850280a88335d1d2d770e5aa2332b801ba7064"
 [[package]]
 name = "makepad-live-compiler"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-derive-live",
  "makepad-live-tokenizer",
@@ -2468,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id-macros",
 ]
@@ -2476,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-id-macros"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2484,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "makepad-live-tokenizer"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id",
  "makepad-math",
@@ -2494,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "makepad-math"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-micro-serde",
 ]
@@ -2502,12 +2486,12 @@ dependencies = [
 [[package]]
 name = "makepad-micro-proc-macro"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-micro-serde"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-id",
  "makepad-micro-serde-derive",
@@ -2516,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "makepad-micro-serde-derive"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2524,12 +2508,12 @@ dependencies = [
 [[package]]
 name = "makepad-objc-sys"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-platform"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "bitflags 2.10.0",
  "hilog-sys",
@@ -2558,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "makepad-rustybuzz"
 version = "0.8.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
@@ -2573,9 +2557,9 @@ dependencies = [
 [[package]]
 name = "makepad-script"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
- "makepad-id",
+ "makepad-live-id",
  "makepad-script-derive",
  "smallvec",
 ]
@@ -2583,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "makepad-script-derive"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-micro-proc-macro",
 ]
@@ -2591,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "makepad-shader-compiler"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-live-compiler",
 ]
@@ -2599,12 +2583,12 @@ dependencies = [
 [[package]]
 name = "makepad-ttf-parser"
 version = "0.21.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "makepad-vector"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-ttf-parser",
  "resvg",
@@ -2613,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "makepad-wasm-bridge"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-derive-wasm-bridge",
  "makepad-live-id",
@@ -2622,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "makepad-widgets"
 version = "1.0.0"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-derive-widget",
  "makepad-draw",
@@ -2641,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-core"
 version = "0.2.14"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -2649,7 +2633,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-jpeg"
 version = "0.3.17"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "makepad-zune-core",
 ]
@@ -2657,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "makepad-zune-png"
 version = "0.4.10"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 dependencies = [
  "zune-core",
  "zune-inflate",
@@ -4299,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sdfer"
 version = "0.2.1"
-source = "git+https://github.com/wyeworks/makepad?rev=5c16b905a#5c16b905aea64d28c67d5a26098d975d4a464e24"
+source = "git+https://github.com/wyeworks/makepad?rev=743585298#7435852986e71382f442be28534558973cfaa211"
 
 [[package]]
 name = "selectors"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ path = "src/main.rs"
 moly-protocol = { git = "https://github.com/moxin-org/moly-server", package = "moly-protocol" }
 moly-kit = { path = "./moly-kit", features = ["full"] }
 moly-sync = { path = "./moly-sync"}
-makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "5c16b905a" }
-makepad-code-editor = { git = "https://github.com/wyeworks/makepad", rev = "5c16b905a" }
+makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "743585298" }
+makepad-code-editor = { git = "https://github.com/wyeworks/makepad", rev = "743585298" }
 
 unicode-segmentation = "1.10.1"
 anyhow = "1.0"

--- a/moly-kit/Cargo.toml
+++ b/moly-kit/Cargo.toml
@@ -18,8 +18,8 @@ url = "2.4.10"
 robius-open = { git = "https://github.com/project-robius/robius", rev = "a62b82c8" }
 async-stream = "0.3.6"
 
-makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "5c16b905a" }
-makepad-code-editor = { git = "https://github.com/wyeworks/makepad", rev = "5c16b905a" }
+makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "743585298" }
+makepad-code-editor = { git = "https://github.com/wyeworks/makepad", rev = "743585298" }
 
 cfg-if = "1.0.0"
 

--- a/moly-kit/examples/moly-mini/Cargo.toml
+++ b/moly-kit/examples/moly-mini/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 env_logger = "0.11.8"
 futures = "0.3.31"
 futures-core = "0.3.31"
-makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "5c16b905a" }
+makepad-widgets = { git = "https://github.com/wyeworks/makepad", rev = "743585298" }
 moly-kit = { path = "../..", features = ["full"] }
 reqwest = { version = "0.12.12", features = ["json", "stream", "rustls-tls"], default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }

--- a/moly-kit/examples/moly-mini/src/bot_selector.rs
+++ b/moly-kit/examples/moly-mini/src/bot_selector.rs
@@ -121,8 +121,8 @@ impl Widget for BotSelector {
                     let bot = &self.bots[index];
 
                     let item = list.item(cx, index, live_id!(Bot));
-                    item.meta(id!(bot)).set_value(bot.clone());
-                    item.button(id!(button)).set_text(cx, &bot.name);
+                    item.meta(ids!(bot)).set_value(bot.clone());
+                    item.button(ids!(button)).set_text(cx, &bot.name);
                     item.draw_all(cx, &mut Scope::empty());
                 }
             }
@@ -135,12 +135,19 @@ impl Widget for BotSelector {
 impl WidgetMatchEvent for BotSelector {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let clicked_bot_id = self
-            .portal_list(id!(list))
+            .portal_list(ids!(list))
             .items_with_actions(actions)
             .iter()
             .find_map(|(_idx, widget)| {
-                if widget.button(id!(button)).clicked(actions) {
-                    Some(widget.meta(id!(bot)).get_value::<Bot>().unwrap().id.clone())
+                if widget.button(ids!(button)).clicked(actions) {
+                    Some(
+                        widget
+                            .meta(ids!(bot))
+                            .get_value::<Bot>()
+                            .unwrap()
+                            .id
+                            .clone(),
+                    )
                 } else {
                     None
                 }
@@ -160,10 +167,10 @@ impl WidgetMatchEvent for BotSelector {
 
 impl BotSelector {
     fn toggle_layout_mode(&mut self, cx: &mut Cx) {
-        if self.animator.animator_in_state(cx, id!(mode.collapsed)) {
-            self.animator_play(cx, id!(mode.expanded));
+        if self.animator.animator_in_state(cx, ids!(mode.collapsed)) {
+            self.animator_play(cx, ids!(mode.expanded));
         } else {
-            self.animator_play(cx, id!(mode.collapsed));
+            self.animator_play(cx, ids!(mode.collapsed));
         }
     }
 
@@ -185,7 +192,7 @@ impl BotSelector {
         let bot = self.bots.remove(index);
         self.bots.insert(0, bot);
 
-        self.portal_list(id!(list)).set_first_id_and_scroll(0, 0.);
+        self.portal_list(ids!(list)).set_first_id_and_scroll(0, 0.);
     }
 
     pub fn bot_selected(&self, actions: &Actions) -> bool {

--- a/moly-kit/examples/moly-mini/src/demo_chat.rs
+++ b/moly-kit/examples/moly-mini/src/demo_chat.rs
@@ -43,8 +43,8 @@ pub struct DemoChat {
 
 impl Widget for DemoChat {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
-        let selector = self.bot_selector(id!(selector));
-        let mut chat = self.chat(id!(chat));
+        let selector = self.bot_selector(ids!(selector));
+        let mut chat = self.chat(ids!(chat));
 
         self.ui_runner().handle(cx, event, scope, self);
         self.deref.handle_event(cx, event, scope);
@@ -74,7 +74,7 @@ impl LiveHook for DemoChat {
 
 impl DemoChat {
     fn fill_selector(&mut self, cx: &mut Cx, bots: Vec<Bot>) {
-        let mut chat = self.chat(id!(chat));
+        let mut chat = self.chat(ids!(chat));
 
         let bots = bots
             .into_iter()
@@ -135,11 +135,11 @@ impl DemoChat {
             eprintln!("No models available, check your API keys.");
         }
 
-        self.bot_selector(id!(selector)).set_bots(bots);
+        self.bot_selector(ids!(selector)).set_bots(bots);
     }
 
     fn setup_chat_hooks(&self) {
-        // self.chat(id!(chat)).write_with(|chat| {
+        // self.chat(ids!(chat)).write_with(|chat| {
         //     chat.set_hook_before(|group, chat, cx| {
         //         let mut abort = false;
 
@@ -266,7 +266,7 @@ impl DemoChat {
         controller.lock().unwrap().dispatch_task(ChatTask::Load);
 
         self.controller = Some(controller.clone());
-        self.chat(id!(chat))
+        self.chat(ids!(chat))
             .write()
             .set_chat_controller(cx, Some(controller));
     }

--- a/moly-kit/examples/moly-mini/src/ui.rs
+++ b/moly-kit/examples/moly-mini/src/ui.rs
@@ -100,8 +100,8 @@ impl Widget for Ui {
             .flatten()
             .collect::<Vec<_>>();
 
-            // self.demo_chat(id!(chat_2))
-            //     .chat(id!(chat))
+            // self.demo_chat(ids!(chat_2))
+            //     .chat(ids!(chat))
             //     .borrow()
             //     .unwrap()
             //     .messages_ref()

--- a/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/deep_inquire_content.rs
@@ -61,7 +61,7 @@ impl DeepInquireContent {
 
         let stages = data.stages.as_slice();
 
-        let mut stages_ui = self.view.stages(id!(stages));
+        let mut stages_ui = self.view.stages(ids!(stages));
         stages_ui.update_stages(cx, stages);
 
         // Check if there is a completion block in any of the stages
@@ -75,7 +75,7 @@ impl DeepInquireContent {
                 .iter()
                 .map(|s| s.text.clone())
                 .collect::<String>();
-            self.markdown(id!(completed_block.completed_markdown))
+            self.markdown(ids!(completed_block.completed_markdown))
                 .set_text(cx, &final_text);
         }
     }

--- a/moly-kit/src/clients/deep_inquire/widgets/stages.rs
+++ b/moly-kit/src/clients/deep_inquire/widgets/stages.rs
@@ -353,10 +353,10 @@ impl WidgetMatchEvent for Stages {
                 StageViewAction::StageViewClicked(clicked_stage) => {
                     match clicked_stage {
                         StageType::Thinking => {
-                            self.stage_view(id!(content_stage)).set_active(cx, false);
+                            self.stage_view(ids!(content_stage)).set_active(cx, false);
                         }
                         StageType::Content => {
-                            self.stage_view(id!(thinking_stage)).set_active(cx, false);
+                            self.stage_view(ids!(thinking_stage)).set_active(cx, false);
                         }
                         _ => {}
                     }
@@ -379,13 +379,13 @@ impl Stages {
         for stage in stages.iter() {
             match stage.stage_type {
                 StageType::Thinking => {
-                    let mut thinking_stage = self.stage_view(id!(thinking_stage));
+                    let mut thinking_stage = self.stage_view(ids!(thinking_stage));
                     thinking_stage.set_stage(cx, &stage);
                     // Thinking streams if content stage doesn't exist yet
                     thinking_stage.set_streaming_state(cx, !has_content_stage);
                 }
                 StageType::Content => {
-                    let mut content_stage = self.stage_view(id!(content_stage));
+                    let mut content_stage = self.stage_view(ids!(content_stage));
                     content_stage.set_stage(cx, &stage);
                     // Content streams if completion stage doesn't exist yet
                     content_stage.set_streaming_state(cx, !has_completion_stage);
@@ -436,21 +436,21 @@ impl Widget for StageView {
         if self.timer.is_event(event).is_some() {
             if self.is_streaming {
                 // Cycle through animation states
-                if self.animator_in_state(cx, id!(streaming.move_up)) {
-                    self.animator_play(cx, id!(streaming.move_right));
-                } else if self.animator_in_state(cx, id!(streaming.move_right)) {
-                    self.animator_play(cx, id!(streaming.move_down));
-                } else if self.animator_in_state(cx, id!(streaming.move_down)) {
-                    self.animator_play(cx, id!(streaming.move_left));
+                if self.animator_in_state(cx, ids!(streaming.move_up)) {
+                    self.animator_play(cx, ids!(streaming.move_right));
+                } else if self.animator_in_state(cx, ids!(streaming.move_right)) {
+                    self.animator_play(cx, ids!(streaming.move_down));
+                } else if self.animator_in_state(cx, ids!(streaming.move_down)) {
+                    self.animator_play(cx, ids!(streaming.move_left));
                 } else {
                     // Assumes it's in move_left or just started
-                    self.animator_play(cx, id!(streaming.move_up));
+                    self.animator_play(cx, ids!(streaming.move_up));
                 }
                 // Restart the timer for the next step
                 self.timer = cx.start_timeout(0.4); // Match state duration
             } else {
                 // If streaming stopped while timer was pending, ensure animation is off
-                self.animator_cut(cx, id!(streaming.off));
+                self.animator_cut(cx, ids!(streaming.off));
                 if !self.timer.is_empty() {
                     cx.stop_timer(self.timer);
                     self.timer = Timer::empty(); // Clear timer
@@ -468,14 +468,14 @@ impl Widget for StageView {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if self.is_active {
-            self.view(id!(stage_toggle)).apply_over(
+            self.view(ids!(stage_toggle)).apply_over(
                 cx,
                 live! {
                     draw_bg: { border_size: 1 }
                 },
             );
         } else {
-            self.view(id!(stage_toggle)).apply_over(
+            self.view(ids!(stage_toggle)).apply_over(
                 cx,
                 live! {
                     draw_bg: { border_size: 0 }
@@ -483,9 +483,9 @@ impl Widget for StageView {
             );
         }
 
-        self.view(id!(expanded_stage_content))
+        self.view(ids!(expanded_stage_content))
             .set_visible(cx, self.is_active);
-        self.view(id!(stage_content_preview))
+        self.view(ids!(stage_content_preview))
             .set_visible(cx, !self.is_active);
 
         self.view.draw_walk(cx, scope, walk)
@@ -494,7 +494,7 @@ impl Widget for StageView {
 
 impl WidgetMatchEvent for StageView {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if let Some(_fe) = self.view(id!(wrapper)).finger_down(actions) {
+        if let Some(_fe) = self.view(ids!(wrapper)).finger_down(actions) {
             self.is_active = !self.is_active;
 
             cx.action(StageViewAction::StageViewClicked(self.stage_type.clone()));
@@ -509,16 +509,16 @@ impl StageView {
         self.stage_type = stage.stage_type.clone();
         self.visible = true;
 
-        self.sub_stages(id!(substages))
+        self.sub_stages(ids!(substages))
             .set_substages(cx, &stage.substages);
 
         if !stage.citations.is_empty() {
-            self.view(id!(citations_view)).set_visible(cx, true);
-            let citations = self.citation_list(id!(citations_list));
+            self.view(ids!(citations_view)).set_visible(cx, true);
+            let citations = self.citation_list(ids!(citations_list));
             let mut citations = citations.borrow_mut().unwrap();
             citations.urls = stage.citations.iter().map(|a| a.url.clone()).collect();
         } else {
-            self.view(id!(citations_view)).set_visible(cx, false);
+            self.view(ids!(citations_view)).set_visible(cx, false);
         }
 
         // TODO: this should be replaced in the future by an AI-provided summary
@@ -546,10 +546,10 @@ impl StageView {
         });
 
         if let Some(stage_preview_text) = stage_preview_text {
-            self.label(id!(stage_preview_label))
+            self.label(ids!(stage_preview_label))
                 .set_text(cx, &format!("{}...", stage_preview_text));
         } else {
-            self.label(id!(stage_preview_label))
+            self.label(ids!(stage_preview_label))
                 .set_text(cx, "Loading...");
         }
 
@@ -566,12 +566,12 @@ impl StageView {
             // Start animation only if timer isn't already running
             if self.timer.is_empty() {
                 // Start the animation cycle
-                self.animator_play(cx, id!(streaming.move_up));
+                self.animator_play(cx, ids!(streaming.move_up));
                 self.timer = cx.start_timeout(0.01); // Start timer almost immediately
             }
         } else {
             // Stop animation and reset state
-            self.animator_cut(cx, id!(streaming.off)); // Go directly to off state
+            self.animator_cut(cx, ids!(streaming.off)); // Go directly to off state
             if !self.timer.is_empty() {
                 cx.stop_timer(self.timer);
                 self.timer = Timer::empty();
@@ -667,13 +667,13 @@ impl SubStages {
                 };
 
             substage_view
-                .label(id!(content_heading_label))
+                .label(ids!(content_heading_label))
                 .set_text(cx, &get_human_readable_stage_name(&substage.name));
             substage_view
-                .view(id!(citations_view))
+                .view(ids!(citations_view))
                 .set_visible(cx, false);
             substage_view
-                .markdown(id!(content_block_markdown))
+                .markdown(ids!(content_block_markdown))
                 .set_text(cx, &substage.text);
         }
     }

--- a/moly-kit/src/widgets/attachment_list.rs
+++ b/moly-kit/src/widgets/attachment_list.rs
@@ -95,11 +95,11 @@ pub struct AttachmentList {
 
 impl Widget for AttachmentList {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        self.view(id!(wrapper))
+        self.view(ids!(wrapper))
             .set_visible(cx, !self.attachments.is_empty());
 
         let attachments_count = self.attachments.len();
-        let list = self.portal_list(id!(list));
+        let list = self.portal_list(ids!(list));
         while let Some(widget) = self.deref.draw_walk(cx, scope, walk).step() {
             if widget.widget_uid() == list.widget_uid() {
                 let mut list = list.borrow_mut().unwrap();
@@ -112,7 +112,7 @@ impl Widget for AttachmentList {
                     let attachment = &self.attachments[index];
                     let item = list.item(cx, index, live_id!(File));
 
-                    item.attachment_view(id!(preview))
+                    item.attachment_view(ids!(preview))
                         .borrow_mut()
                         .unwrap()
                         .set_attachment(cx, attachment.clone());

--- a/moly-kit/src/widgets/attachment_view.rs
+++ b/moly-kit/src/widgets/attachment_view.rs
@@ -95,9 +95,9 @@ impl AttachmentView {
             // Preserve for future comparisons.
             self.attachment = attachment;
 
-            let icon = self.label(id!(icon));
-            let tag_label = self.label(id!(tag_label));
-            let title = self.label(id!(title));
+            let icon = self.label(ids!(icon));
+            let tag_label = self.label(ids!(tag_label));
+            let title = self.label(ids!(title));
 
             self.icon_wrapper_ref().set_visible(cx, true);
             self.image_wrapper_ref().set_visible(cx, false);
@@ -155,19 +155,19 @@ impl AttachmentView {
     }
 
     fn image_ref(&self) -> ImageViewRef {
-        self.image_view(id!(image))
+        self.image_view(ids!(image))
     }
 
     fn image_wrapper_ref(&self) -> ViewRef {
-        self.view(id!(image_wrapper))
+        self.view(ids!(image_wrapper))
     }
 
     fn icon_wrapper_ref(&self) -> ViewRef {
-        self.view(id!(icon_wrapper))
+        self.view(ids!(icon_wrapper))
     }
 
     fn tag_bg_ref(&self) -> ViewRef {
-        self.view(id!(tag_bg))
+        self.view(ids!(tag_bg))
     }
 
     fn try_load_preview(&mut self) {

--- a/moly-kit/src/widgets/attachment_viewer_modal.rs
+++ b/moly-kit/src/widgets/attachment_viewer_modal.rs
@@ -54,15 +54,15 @@ impl Widget for AttachmentViewerModal {
     fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
         self.deref.handle_event(cx, event, scope);
 
-        if self.button(id!(modal.save)).clicked(event.actions()) {
-            self.attachment_view(id!(attachment))
+        if self.button(ids!(modal.save)).clicked(event.actions()) {
+            self.attachment_view(ids!(attachment))
                 .borrow()
                 .unwrap()
                 .get_attachment()
                 .save();
         }
 
-        if self.button(id!(modal.close)).clicked(event.actions()) {
+        if self.button(ids!(modal.close)).clicked(event.actions()) {
             self.close(cx)
         }
     }
@@ -71,7 +71,7 @@ impl Widget for AttachmentViewerModal {
 impl AttachmentViewerModal {
     pub fn open(&mut self, cx: &mut Cx, attachment: Attachment) {
         self.modal_ref().open(cx);
-        self.attachment_view(id!(attachment))
+        self.attachment_view(ids!(attachment))
             .borrow_mut()
             .unwrap()
             .set_attachment(cx, attachment);
@@ -82,6 +82,6 @@ impl AttachmentViewerModal {
     }
 
     fn modal_ref(&self) -> MolyModalRef {
-        self.moly_modal(id!(modal))
+        self.moly_modal(ids!(modal))
     }
 }

--- a/moly-kit/src/widgets/avatar.rs
+++ b/moly-kit/src/widgets/avatar.rs
@@ -66,15 +66,15 @@ impl Widget for Avatar {
         if let Some(avatar) = &self.avatar {
             match avatar {
                 Picture::Grapheme(grapheme) => {
-                    self.view(id!(grapheme)).set_visible(cx, true);
-                    self.view(id!(dependency)).set_visible(cx, false);
-                    self.label(id!(label)).set_text(cx, &grapheme);
+                    self.view(ids!(grapheme)).set_visible(cx, true);
+                    self.view(ids!(dependency)).set_visible(cx, false);
+                    self.label(ids!(label)).set_text(cx, &grapheme);
                 }
                 Picture::Dependency(dependency) => {
-                    self.view(id!(dependency)).set_visible(cx, true);
-                    self.view(id!(grapheme)).set_visible(cx, false);
+                    self.view(ids!(dependency)).set_visible(cx, true);
+                    self.view(ids!(grapheme)).set_visible(cx, false);
                     let _ = self
-                        .image(id!(image))
+                        .image(ids!(image))
                         .load_image_dep_by_path(cx, dependency.as_str());
                 }
                 _ => unimplemented!(),

--- a/moly-kit/src/widgets/chat.rs
+++ b/moly-kit/src/widgets/chat.rs
@@ -83,12 +83,12 @@ impl Widget for Chat {
 impl Chat {
     /// Getter to the underlying [PromptInputRef] independent of its id.
     pub fn prompt_input_ref(&self) -> PromptInputRef {
-        self.prompt_input(id!(prompt))
+        self.prompt_input(ids!(prompt))
     }
 
     /// Getter to the underlying [MessagesRef] independent of its id.
     pub fn messages_ref(&self) -> MessagesRef {
-        self.messages(id!(messages))
+        self.messages(ids!(messages))
     }
 
     fn handle_prompt_input(&mut self, cx: &mut Cx, event: &Event) {
@@ -102,7 +102,7 @@ impl Chat {
     }
 
     fn handle_realtime(&mut self, _cx: &mut Cx) {
-        if self.realtime(id!(realtime)).connection_requested()
+        if self.realtime(ids!(realtime)).connection_requested()
             && let Some(bot_id) = self.bot_id.clone()
         {
             self.chat_controller
@@ -118,18 +118,21 @@ impl Chat {
         // Check if the modal should be dismissed
         for action in event.actions() {
             if let RealtimeModalAction::DismissModal = action.cast() {
-                self.moly_modal(id!(audio_modal)).close(cx);
+                self.moly_modal(ids!(audio_modal)).close(cx);
             }
         }
 
         // Check if the audio modal was dismissed
-        if self.moly_modal(id!(audio_modal)).dismissed(event.actions()) {
+        if self
+            .moly_modal(ids!(audio_modal))
+            .dismissed(event.actions())
+        {
             // Collect conversation messages from the realtime widget before resetting
             let mut conversation_messages =
-                self.realtime(id!(realtime)).take_conversation_messages();
+                self.realtime(ids!(realtime)).take_conversation_messages();
 
             // Reset realtime widget state for cleanup
-            self.realtime(id!(realtime)).reset_state(cx);
+            self.realtime(ids!(realtime)).reset_state(cx);
 
             // Add conversation messages to chat history preserving order
             if !conversation_messages.is_empty() {
@@ -418,7 +421,7 @@ impl Chat {
         self.chat_controller = chat_controller;
 
         self.messages_ref().write().chat_controller = self.chat_controller.clone();
-        self.realtime(id!(realtime))
+        self.realtime(ids!(realtime))
             .set_chat_controller(self.chat_controller.clone());
 
         if let Some(controller) = self.chat_controller.as_ref() {
@@ -539,11 +542,11 @@ impl ChatControllerPlugin for Plugin {
                     me.handle_streaming_end(cx);
 
                     // Set up the realtime channel in the UI
-                    let mut realtime = me.realtime(id!(realtime));
+                    let mut realtime = me.realtime(ids!(realtime));
                     realtime.set_bot_entity_id(cx, entity_id);
                     realtime.set_realtime_channel(channel.clone());
 
-                    let modal = me.moly_modal(id!(audio_modal));
+                    let modal = me.moly_modal(ids!(audio_modal));
                     modal.open(cx);
                 });
                 None

--- a/moly-kit/src/widgets/citation.rs
+++ b/moly-kit/src/widgets/citation.rs
@@ -110,8 +110,8 @@ impl Citation {
     }
 
     fn set_initial_info(&mut self, cx: &mut Cx) {
-        let site = self.label(id!(site));
-        let title = self.label(id!(title));
+        let site = self.label(ids!(site));
+        let title = self.label(ids!(title));
         let url = self.url.as_deref().unwrap();
 
         site.set_text(cx, url);
@@ -119,8 +119,8 @@ impl Citation {
     }
 
     fn try_refine_info(&mut self, cx: &mut Cx) -> Result<(), ()> {
-        let site = self.label(id!(site));
-        let title = self.label(id!(title));
+        let site = self.label(ids!(site));
+        let title = self.label(ids!(title));
         let url = self.url.as_deref().unwrap();
 
         let url = Url::parse(url).map_err(|_| ())?;
@@ -142,7 +142,7 @@ impl Citation {
 
             if let Some(title) = extract_title(&document) {
                 ui.defer_with_redraw(move |me, cx, _| {
-                    me.label(id!(title)).set_text(cx, &title);
+                    me.label(ids!(title)).set_text(cx, &title);
                 });
             }
 

--- a/moly-kit/src/widgets/citation_list.rs
+++ b/moly-kit/src/widgets/citation_list.rs
@@ -36,7 +36,7 @@ pub struct CitationList {
 
 impl Widget for CitationList {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let list_uid = self.portal_list(id!(list)).widget_uid();
+        let list_uid = self.portal_list(ids!(list)).widget_uid();
         while let Some(widget) = self.deref.draw_walk(cx, scope, walk).step() {
             if widget.widget_uid() == list_uid {
                 self.draw_list(cx, &mut *widget.as_portal_list().borrow_mut().unwrap());

--- a/moly-kit/src/widgets/image_view.rs
+++ b/moly-kit/src/widgets/image_view.rs
@@ -125,7 +125,7 @@ impl ImageView {
     }
 
     fn image_ref(&self) -> ImageRef {
-        self.image(id!(image))
+        self.image(ids!(image))
     }
 
     fn image_size(&self, cx: &mut Cx) -> (usize, usize) {

--- a/moly-kit/src/widgets/message_loading.rs
+++ b/moly-kit/src/widgets/message_loading.rs
@@ -134,16 +134,16 @@ impl MessageLoading {
 
         match self.current_animated_bar {
             0 => {
-                self.animator_play(cx, id!(line1.run));
-                self.animator_play(cx, id!(line3.start));
+                self.animator_play(cx, ids!(line1.run));
+                self.animator_play(cx, ids!(line3.start));
             }
             1 => {
-                self.animator_play(cx, id!(line1.start));
-                self.animator_play(cx, id!(line2.run));
+                self.animator_play(cx, ids!(line1.start));
+                self.animator_play(cx, ids!(line2.run));
             }
             2 => {
-                self.animator_play(cx, id!(line2.start));
-                self.animator_play(cx, id!(line3.run));
+                self.animator_play(cx, ids!(line2.start));
+                self.animator_play(cx, ids!(line3.run));
             }
             _ => unreachable!(),
         };

--- a/moly-kit/src/widgets/message_thinking_block.rs
+++ b/moly-kit/src/widgets/message_thinking_block.rs
@@ -197,7 +197,7 @@ impl Widget for MessageThinkingBlock {
 
 impl WidgetMatchEvent for MessageThinkingBlock {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if let Some(_evt) = self.view(id!(collapse)).finger_up(&actions) {
+        if let Some(_evt) = self.view(ids!(collapse)).finger_up(&actions) {
             self.toggle_collapse(cx);
         }
     }
@@ -210,12 +210,12 @@ impl MessageThinkingBlock {
 
         match self.current_animated_ball {
             0 => {
-                self.animator_play(cx, id!(ball1.run));
-                self.animator_play(cx, id!(ball2.start));
+                self.animator_play(cx, ids!(ball1.run));
+                self.animator_play(cx, ids!(ball2.start));
             }
             1 => {
-                self.animator_play(cx, id!(ball1.start));
-                self.animator_play(cx, id!(ball2.run));
+                self.animator_play(cx, ids!(ball1.start));
+                self.animator_play(cx, ids!(ball2.run));
             }
             _ => unreachable!(),
         }
@@ -235,7 +235,7 @@ impl MessageThinkingBlock {
 
         self.is_visible = !content_reasoning.is_empty();
 
-        self.markdown(id!(thinking_text))
+        self.markdown(ids!(thinking_text))
             .set_text(cx, content_reasoning);
 
         let is_reasoning_ongoing =
@@ -244,15 +244,15 @@ impl MessageThinkingBlock {
         if is_reasoning_ongoing {
             if self.timer.is_empty() {
                 self.should_animate = true;
-                self.view(id!(balls)).set_visible(cx, true);
+                self.view(ids!(balls)).set_visible(cx, true);
                 self.update_animation(cx);
             }
         } else {
             self.should_animate = false;
-            self.view(id!(balls)).set_visible(cx, false);
-            self.animator_play(cx, id!(ball1.start));
-            self.animator_play(cx, id!(ball2.start));
-            self.view(id!(thinking_title)).set_text(
+            self.view(ids!(balls)).set_visible(cx, false);
+            self.animator_play(cx, ids!(ball1.start));
+            self.animator_play(cx, ids!(ball2.start));
+            self.view(ids!(thinking_title)).set_text(
                 cx,
                 &format!(
                     "Thought for {:0.2} seconds",
@@ -267,21 +267,21 @@ impl MessageThinkingBlock {
 
         if self.is_expanded {
             // Expand the content to fit the text
-            self.view(id!(content)).apply_over(
+            self.view(ids!(content)).apply_over(
                 cx,
                 live! {
                     height: Fit
                 },
             );
             // Expand the inner view to fit the content
-            self.view(id!(inner)).apply_over(
+            self.view(ids!(inner)).apply_over(
                 cx,
                 live! {
                     width: Fill
                 },
             );
             // Set a different color to the title background
-            self.view(id!(collapse)).apply_over(
+            self.view(ids!(collapse)).apply_over(
                 cx,
                 live! {
                     draw_bg: {
@@ -291,21 +291,21 @@ impl MessageThinkingBlock {
             );
         } else {
             // Collapse the content
-            self.view(id!(content)).apply_over(
+            self.view(ids!(content)).apply_over(
                 cx,
                 live! {
                     height: 0.0
                 },
             );
             // Set the inner view width back to the default
-            self.view(id!(inner)).apply_over(
+            self.view(ids!(inner)).apply_over(
                 cx,
                 live! {
                     width: 200
                 },
             );
             // Set the title background color back to the default
-            self.view(id!(collapse)).apply_over(
+            self.view(ids!(collapse)).apply_over(
                 cx,
                 live! {
                     draw_bg: {

--- a/moly-kit/src/widgets/messages.rs
+++ b/moly-kit/src/widgets/messages.rs
@@ -165,7 +165,7 @@ impl Widget for Messages {
         self.deref.handle_event(cx, event, scope);
         self.handle_list(cx, event, scope);
 
-        let jump_to_bottom = self.button(id!(jump_to_bottom));
+        let jump_to_bottom = self.button(ids!(jump_to_bottom));
 
         if jump_to_bottom.clicked(event.actions()) {
             self.animated_scroll_to_bottom(cx);
@@ -180,7 +180,7 @@ impl Widget for Messages {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let list_uid = self.portal_list(id!(list)).widget_uid();
+        let list_uid = self.portal_list(ids!(list)).widget_uid();
 
         while let Some(widget) = self.deref.draw_walk(cx, scope, walk).step() {
             if widget.widget_uid() == list_uid {
@@ -246,19 +246,19 @@ impl Messages {
                     let item = if message.metadata.is_writing() {
                         // Show loading animation for system messages that are being written
                         let item = list.item(cx, index, live_id!(LoadingLine));
-                        item.message_loading(id!(content_section.loading))
+                        item.message_loading(ids!(content_section.loading))
                             .animate(cx);
                         item
                     } else {
                         list.item(cx, index, live_id!(SystemLine))
                     };
 
-                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                    item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar =
                         Some(Picture::Grapheme("S".into()));
-                    item.label(id!(name)).set_text(cx, "System");
+                    item.label(ids!(name)).set_text(cx, "System");
 
                     if !message.metadata.is_writing() {
-                        item.slot(id!(content))
+                        item.slot(ids!(content))
                             .current()
                             .as_standard_message_content()
                             .set_content(cx, &message.content);
@@ -272,19 +272,19 @@ impl Messages {
                     let item = if message.metadata.is_writing() {
                         // Show loading animation for tool execution
                         let item = list.item(cx, index, live_id!(LoadingLine));
-                        item.message_loading(id!(content_section.loading))
+                        item.message_loading(ids!(content_section.loading))
                             .animate(cx);
                         item
                     } else {
                         list.item(cx, index, live_id!(ToolResultLine))
                     };
 
-                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                    item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar =
                         Some(Picture::Grapheme("T".into()));
-                    item.label(id!(name)).set_text(cx, "Tool");
+                    item.label(ids!(name)).set_text(cx, "Tool");
 
                     if !message.metadata.is_writing() {
-                        item.slot(id!(content))
+                        item.slot(ids!(content))
                             .current()
                             .as_standard_message_content()
                             .set_content(cx, &message.content);
@@ -311,15 +311,15 @@ impl Messages {
                             .as_deref()
                         {
                             let item = list.item(cx, index, live_id!(ErrorLine));
-                            item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                            item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar =
                                 Some(Picture::Grapheme("X".into()));
-                            item.label(id!(name)).set_text(cx, left);
+                            item.label(ids!(name)).set_text(cx, left);
 
                             let error_content = MessageContent {
                                 text: right.to_string(),
                                 ..Default::default()
                             };
-                            item.slot(id!(content))
+                            item.slot(ids!(content))
                                 .current()
                                 .as_standard_message_content()
                                 .set_content(cx, &error_content);
@@ -332,10 +332,10 @@ impl Messages {
 
                     // Handle regular app messages
                     let item = list.item(cx, index, live_id!(AppLine));
-                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                    item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar =
                         Some(Picture::Grapheme("A".into()));
 
-                    item.slot(id!(content))
+                    item.slot(ids!(content))
                         .current()
                         .as_standard_message_content()
                         .set_content(cx, &message.content);
@@ -346,11 +346,11 @@ impl Messages {
                 EntityId::User => {
                     let item = list.item(cx, index, live_id!(UserLine));
 
-                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar =
+                    item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar =
                         Some(Picture::Grapheme("Y".into()));
-                    item.label(id!(name)).set_text(cx, "You");
+                    item.label(ids!(name)).set_text(cx, "You");
 
-                    item.slot(id!(content))
+                    item.slot(ids!(content))
                         .current()
                         .as_standard_message_content()
                         .set_content(cx, &message.content);
@@ -369,7 +369,7 @@ impl Messages {
                     let item =
                         if message.metadata.is_writing() && message.content.is_empty() {
                             let item = list.item(cx, index, live_id!(LoadingLine));
-                            item.message_loading(id!(content_section.loading))
+                            item.message_loading(ids!(content_section.loading))
                                 .animate(cx);
                             item
                         } else if !message.content.tool_calls.is_empty() {
@@ -385,14 +385,14 @@ impl Messages {
                                 });
 
                             // Show/hide tool actions based on status
-                            item.view(id!(tool_actions)).set_visible(cx, has_pending);
+                            item.view(ids!(tool_actions)).set_visible(cx, has_pending);
 
                             // Set status text, only show if denied
                             if has_denied {
-                                item.view(id!(status_view)).set_visible(cx, true);
-                                item.label(id!(approved_status)).set_text(cx, "Denied");
+                                item.view(ids!(status_view)).set_visible(cx, true);
+                                item.label(ids!(approved_status)).set_text(cx, "Denied");
                             } else {
-                                item.view(id!(status_view)).set_visible(cx, false);
+                                item.view(ids!(status_view)).set_visible(cx, false);
                             }
 
                             item
@@ -400,10 +400,10 @@ impl Messages {
                             list.item(cx, index, live_id!(BotLine))
                         };
 
-                    item.avatar(id!(avatar)).borrow_mut().unwrap().avatar = Some(avatar);
-                    item.label(id!(name)).set_text(cx, name);
+                    item.avatar(ids!(avatar)).borrow_mut().unwrap().avatar = Some(avatar);
+                    item.label(ids!(name)).set_text(cx, name);
 
-                    let mut slot = item.slot(id!(content));
+                    let mut slot = item.slot(ids!(content));
                     if let Some(custom_content) = bot_client.as_mut().and_then(|bc| {
                         bc.content_widget(
                             cx,
@@ -442,7 +442,7 @@ impl Messages {
             assert!(message.content.text == "EOC");
         }
 
-        self.button(id!(jump_to_bottom))
+        self.button(ids!(jump_to_bottom))
             .set_visible(cx, !self.is_at_bottom());
     }
 
@@ -459,7 +459,7 @@ impl Messages {
             .expect("no chat controller set");
 
         if chat_controller.lock().unwrap().state().messages.len() > 0 {
-            let list = self.portal_list(id!(list));
+            let list = self.portal_list(ids!(list));
 
             // Use immediate scroll instead of smooth scroll to prevent continuous scroll actions
             list.set_first_id_and_scroll(
@@ -493,7 +493,7 @@ impl Messages {
             .expect("no chat controller set");
 
         if chat_controller.lock().unwrap().state().messages.len() > 0 {
-            let list = self.portal_list(id!(list));
+            let list = self.portal_list(ids!(list));
             list.smooth_scroll_to_end(cx, 100.0, None);
         }
     }
@@ -529,8 +529,8 @@ impl Messages {
     pub fn current_editor_text(&self) -> Option<String> {
         self.current_editor
             .as_ref()
-            .and_then(|editor| self.portal_list(id!(list)).get_item(editor.index))
-            .map(|(_id, widget)| widget.text_input(id!(input)).text())
+            .and_then(|editor| self.portal_list(ids!(list)).get_item(editor.index))
+            .map(|(_id, widget)| widget.text_input(ids!(input)).text())
     }
 
     /// If currently editing a message, this will return the index of the message.
@@ -543,7 +543,7 @@ impl Messages {
             return;
         };
 
-        let list = self.portal_list(id!(list));
+        let list = self.portal_list(ids!(list));
         let range = range.0..=range.1;
 
         // Handle item actions
@@ -557,11 +557,11 @@ impl Messages {
 
             let actions = event.actions();
 
-            if item.button(id!(copy)).clicked(actions) {
+            if item.button(ids!(copy)).clicked(actions) {
                 cx.widget_action(self.widget_uid(), &scope.path, MessagesAction::Copy(index));
             }
 
-            if item.button(id!(delete)).clicked(actions) {
+            if item.button(ids!(delete)).clicked(actions) {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
@@ -569,19 +569,19 @@ impl Messages {
                 );
             }
 
-            if item.button(id!(edit)).clicked(actions) {
+            if item.button(ids!(edit)).clicked(actions) {
                 self.set_message_editor_visibility(index, true);
                 self.redraw(cx);
             }
 
-            if item.button(id!(edit_actions.cancel)).clicked(actions) {
+            if item.button(ids!(edit_actions.cancel)).clicked(actions) {
                 self.set_message_editor_visibility(index, false);
                 self.redraw(cx);
             }
 
             // Being more explicit because makepad query may actually check for
             // other save button somewhere else (like in the image viewer modal).
-            if item.button(id!(edit_actions.save)).clicked(actions) {
+            if item.button(ids!(edit_actions.save)).clicked(actions) {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
@@ -590,7 +590,7 @@ impl Messages {
             }
 
             if item
-                .button(id!(edit_actions.save_and_regenerate))
+                .button(ids!(edit_actions.save_and_regenerate))
                 .clicked(actions)
             {
                 cx.widget_action(
@@ -600,7 +600,7 @@ impl Messages {
                 );
             }
 
-            if item.button(id!(tool_actions.approve)).clicked(actions) {
+            if item.button(ids!(tool_actions.approve)).clicked(actions) {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
@@ -608,7 +608,7 @@ impl Messages {
                 );
             }
 
-            if item.button(id!(tool_actions.deny)).clicked(actions) {
+            if item.button(ids!(tool_actions.deny)).clicked(actions) {
                 cx.widget_action(
                     self.widget_uid(),
                     &scope.path,
@@ -616,17 +616,17 @@ impl Messages {
                 );
             }
 
-            if let Some(change) = item.text_input(id!(input)).changed(actions) {
+            if let Some(change) = item.text_input(ids!(input)).changed(actions) {
                 self.current_editor.as_mut().unwrap().buffer = change;
             }
         }
 
         // Handle code copy
         // Since the Markdown widget could have multiple code blocks, we need the widget that triggered the action
-        if let Some(wa) = event.actions().widget_action(id!(copy_code_button)) {
+        if let Some(wa) = event.actions().widget_action(ids!(copy_code_button)) {
             if wa.widget().as_button().pressed(event.actions()) {
                 // nth(2) refers to the code view in the MessageMarkdown widget
-                let code_view = wa.widget_nth(2).widget(id!(code_view));
+                let code_view = wa.widget_nth(2).widget(ids!(code_view));
                 let text_to_copy = code_view.as_code_view().text();
                 cx.copy_to_clipboard(&text_to_copy);
             }
@@ -639,10 +639,10 @@ impl Messages {
         widget: &WidgetRef,
         index: usize,
     ) {
-        let editor = widget.view(id!(editor));
-        let actions = widget.view(id!(actions));
-        let edit_actions = widget.view(id!(edit_actions));
-        let content_section = widget.view(id!(content_section));
+        let editor = widget.view(ids!(editor));
+        let actions = widget.view(ids!(actions));
+        let edit_actions = widget.view(ids!(edit_actions));
+        let content_section = widget.view(ids!(content_section));
 
         let is_hovered = self.hovered_index == Some(index);
         let is_current_editor = self.current_editor.as_ref().map(|e| e.index) == Some(index);
@@ -654,7 +654,7 @@ impl Messages {
 
         if is_current_editor {
             editor
-                .text_input(id!(input))
+                .text_input(ids!(input))
                 .set_text(cx, &self.current_editor.as_ref().unwrap().buffer);
         }
     }

--- a/moly-kit/src/widgets/prompt_input.rs
+++ b/moly-kit/src/widgets/prompt_input.rs
@@ -213,7 +213,7 @@ impl Widget for PromptInput {
         self.deref.handle_event(cx, event, scope);
         self.ui_runner().handle(cx, event, scope, self);
 
-        if self.button(id!(attach)).clicked(event.actions()) {
+        if self.button(ids!(attach)).clicked(event.actions()) {
             let ui = self.ui_runner();
             Attachment::pick_multiple(move |result| match result {
                 Ok(attachments) => {
@@ -231,7 +231,7 @@ impl Widget for PromptInput {
     }
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
-        let button = self.button(id!(submit));
+        let button = self.button(ids!(submit));
 
         match self.task {
             Task::Send => {
@@ -299,14 +299,14 @@ impl PromptInput {
     /// Note: To know what the button submission means, check [Self::task] or
     /// the utility methods.
     pub fn submitted(&self, actions: &Actions) -> bool {
-        let submit = self.button(id!(submit));
+        let submit = self.button(ids!(submit));
         let input = self.text_input_ref();
         (submit.clicked(actions) || input.returned(actions).is_some())
             && self.interactivity == Interactivity::Enabled
     }
 
     pub fn call_pressed(&self, actions: &Actions) -> bool {
-        self.button(id!(audio)).clicked(actions)
+        self.button(ids!(audio)).clicked(actions)
     }
 
     /// Shorthand to check if [Self::task] is set to [Task::Send].
@@ -340,7 +340,7 @@ impl PromptInput {
     }
 
     pub(crate) fn attachment_list_ref(&self) -> AttachmentListRef {
-        self.attachment_list(id!(attachments))
+        self.attachment_list(ids!(attachments))
     }
 
     /// Set the capabilities of the currently selected bot
@@ -370,7 +370,7 @@ impl PromptInput {
             target_os = "linux",
             target_arch = "wasm32"
         ))]
-        self.button(id!(attach))
+        self.button(ids!(attach))
             .set_visible(cx, supports_attachments);
 
         #[cfg(not(any(
@@ -379,13 +379,13 @@ impl PromptInput {
             target_os = "linux",
             target_arch = "wasm32"
         )))]
-        self.button(id!(attach)).set_visible(cx, false);
+        self.button(ids!(attach)).set_visible(cx, false);
 
         // Show audio/call button only if bot supports realtime, we're on a supported platform
         // and realtime feature is enabled
         #[cfg(not(target_arch = "wasm32"))]
         #[cfg(feature = "realtime")]
-        self.button(id!(audio)).set_visible(cx, supports_realtime);
+        self.button(ids!(audio)).set_visible(cx, supports_realtime);
 
         if supports_realtime {
             self.interactivity = Interactivity::Disabled;

--- a/moly-kit/src/widgets/realtime.rs
+++ b/moly-kit/src/widgets/realtime.rs
@@ -606,7 +606,7 @@ impl Widget for Realtime {
         self.widget_match_event(cx, event, scope);
 
         if let Some(_value) = self
-            .drop_down(id!(transcription_model_selector))
+            .drop_down(ids!(transcription_model_selector))
             .changed(event.actions())
         {
             if self.is_connected {
@@ -615,7 +615,7 @@ impl Widget for Realtime {
         }
 
         if let Some(enabled) = self
-            .check_box(id!(toggle_interruptions))
+            .check_box(ids!(toggle_interruptions))
             .changed(event.actions())
         {
             // // Send interruption configuration to the realtime client
@@ -647,20 +647,20 @@ impl Widget for Realtime {
                         self.mic_permission_status = MicPermissionStatus::Granted;
                         self.setup_audio(cx);
                         self.audio_setup_done = true;
-                        self.view(id!(start_stop_button)).set_visible(cx, true);
+                        self.view(ids!(start_stop_button)).set_visible(cx, true);
                     }
                     PermissionStatus::DeniedCanRetry => {
-                        self.label(id!(status_label)).set_text(cx, "⚠️ Moly needs microphone access to have realtime conversations.\nClick on the button below to trigger another request");
-                        self.view(id!(request_permission_button))
+                        self.label(ids!(status_label)).set_text(cx, "⚠️ Moly needs microphone access to have realtime conversations.\nClick on the button below to trigger another request");
+                        self.view(ids!(request_permission_button))
                             .set_visible(cx, true);
-                        self.view(id!(start_stop_button)).set_visible(cx, false);
+                        self.view(ids!(start_stop_button)).set_visible(cx, false);
                         self.mic_permission_status = MicPermissionStatus::Denied;
                     }
                     _ => {
-                        self.label(id!(status_label)).set_text(cx, "⚠️ Moly does not have access to your microphone.\nTo continue, allow Moly to access your microphone\nin your system settings\nand then restart the app.");
-                        self.view(id!(request_permission_button))
+                        self.label(ids!(status_label)).set_text(cx, "⚠️ Moly does not have access to your microphone.\nTo continue, allow Moly to access your microphone\nin your system settings\nand then restart the app.");
+                        self.view(ids!(request_permission_button))
                             .set_visible(cx, false);
-                        self.view(id!(start_stop_button)).set_visible(cx, false);
+                        self.view(ids!(start_stop_button)).set_visible(cx, false);
                         self.mic_permission_status = MicPermissionStatus::Denied;
                     }
                 }
@@ -681,7 +681,7 @@ impl Widget for Realtime {
                 // This is the backup mechanism for when toggle is OFF (no interruptions)
                 if self.playback_audio.lock().unwrap().is_empty() {
                     let interruptions_enabled =
-                        self.check_box(id!(toggle_interruptions)).active(cx);
+                        self.check_box(ids!(toggle_interruptions)).active(cx);
 
                     if !interruptions_enabled {
                         // Only auto-resume recording if interruptions are disabled
@@ -693,7 +693,7 @@ impl Widget for Realtime {
                                     "Auto-resuming recording - playback empty and interruptions disabled"
                                 );
                                 *should_record = true;
-                                self.label(id!(status_label))
+                                self.label(ids!(status_label))
                                     .set_text(cx, "🎤 Listening...");
                             }
                         }
@@ -741,11 +741,11 @@ impl WidgetMatchEvent for Realtime {
                 }
             });
 
-        let mic_dropdown = self.drop_down(id!(mic_selector.device_selector));
+        let mic_dropdown = self.drop_down(ids!(mic_selector.device_selector));
         mic_dropdown.set_labels(cx, input_names.clone());
         mic_dropdown.set_selected_by_label(&default_input_name, cx);
 
-        let speaker_dropdown = self.drop_down(id!(speaker_selector.device_selector));
+        let speaker_dropdown = self.drop_down(ids!(speaker_selector.device_selector));
         speaker_dropdown.set_labels(cx, output_names.clone());
         speaker_dropdown.set_selected_by_label(&default_output_name, cx);
 
@@ -779,7 +779,7 @@ impl WidgetMatchEvent for Realtime {
 
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         if self
-            .view(id!(start_stop_button))
+            .view(ids!(start_stop_button))
             .finger_down(actions)
             .is_some()
         {
@@ -793,22 +793,22 @@ impl WidgetMatchEvent for Realtime {
 
         // Handle tool permission buttons from ToolRequestLine
         if self
-            .view(id!(tool_permission_line))
-            .button(id!(message_section.content_section.tool_actions.approve))
+            .view(ids!(tool_permission_line))
+            .button(ids!(message_section.content_section.tool_actions.approve))
             .clicked(actions)
         {
             self.approve_tool_call(cx);
         }
 
         if self
-            .view(id!(tool_permission_line))
-            .button(id!(message_section.content_section.tool_actions.deny))
+            .view(ids!(tool_permission_line))
+            .button(ids!(message_section.content_section.tool_actions.deny))
             .clicked(actions)
         {
             self.deny_tool_call(cx);
         }
 
-        let speaker_dropdown = self.drop_down(id!(speaker_selector.device_selector));
+        let speaker_dropdown = self.drop_down(ids!(speaker_selector.device_selector));
         if let Some(_id) = speaker_dropdown.changed(actions) {
             let selected_device = self
                 .audio_devices
@@ -819,7 +819,7 @@ impl WidgetMatchEvent for Realtime {
             }
         }
 
-        let microphone_dropdown = self.drop_down(id!(mic_selector.device_selector));
+        let microphone_dropdown = self.drop_down(ids!(mic_selector.device_selector));
         if let Some(_id) = microphone_dropdown.changed(actions) {
             let selected_device = self
                 .audio_devices
@@ -831,9 +831,9 @@ impl WidgetMatchEvent for Realtime {
         }
 
         // Mute
-        let mute_button = self.button(id!(mute_button));
-        let mute_label = self.label(id!(mute_status));
-        if self.view(id!(mute_control)).finger_down(actions).is_some()
+        let mute_button = self.button(ids!(mute_button));
+        let mute_label = self.label(ids!(mute_status));
+        if self.view(ids!(mute_control)).finger_down(actions).is_some()
             || mute_button.clicked(actions)
         {
             let mut is_muted = self.is_muted.lock().unwrap();
@@ -851,7 +851,7 @@ impl WidgetMatchEvent for Realtime {
 
         // Mic permissions
         if self
-            .view(id!(request_permission_button))
+            .view(ids!(request_permission_button))
             .finger_up(actions)
             .is_some()
         {
@@ -859,7 +859,7 @@ impl WidgetMatchEvent for Realtime {
         }
 
         // Modal close
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             self.reset_state(cx);
             cx.action(RealtimeModalAction::DismissModal);
         }
@@ -885,7 +885,7 @@ impl Realtime {
                     "gpt-4o-transcribe".to_string(),
                     "gpt-4o-mini-transcribe".to_string(),
                 ];
-                self.drop_down(id!(transcription_model_selector))
+                self.drop_down(ids!(transcription_model_selector))
                     .set_labels(cx, labels);
             }
         }
@@ -925,7 +925,7 @@ impl Realtime {
             // Set flag to request reconnection, Chat widget will handle this
             self.should_request_connection = true;
             self.connection_request_sent = false;
-            self.label(id!(status_label))
+            self.label(ids!(status_label))
                 .set_text(cx, "Reconnecting...");
             return;
         }
@@ -945,7 +945,7 @@ impl Realtime {
         self.transcript.clear();
 
         self.update_ui(cx);
-        self.label(id!(status_label)).set_text(cx, "Loading..."); // This will be removed by the greeting message
+        self.label(ids!(status_label)).set_text(cx, "Loading..."); // This will be removed by the greeting message
         self.start_audio_streaming(cx);
         self.create_greeting_response(cx);
     }
@@ -994,15 +994,16 @@ impl Realtime {
             self.connection_request_sent = false;
         }
         self.transcript.clear();
-        self.label(id!(status_label)).set_text(cx, status_message);
+        self.label(ids!(status_label)).set_text(cx, status_message);
 
         // Hide tool permission UI and clear pending tool call
-        self.view(id!(tool_permission_line)).set_visible(cx, false);
+        self.view(ids!(tool_permission_line)).set_visible(cx, false);
         self.pending_tool_call = None;
 
         // Show voice selector again
-        self.view(id!(voice_selector_wrapper)).set_visible(cx, true);
-        self.view(id!(selected_voice_view)).set_visible(cx, false);
+        self.view(ids!(voice_selector_wrapper))
+            .set_visible(cx, true);
+        self.view(ids!(selected_voice_view)).set_visible(cx, false);
 
         self.update_ui(cx);
     }
@@ -1064,7 +1065,7 @@ impl Realtime {
         for event in events {
             match event {
                 RealtimeEvent::SessionReady => {
-                    self.label(id!(connection_status))
+                    self.label(ids!(connection_status))
                         .set_text(cx, "✅ Connected to OpenAI");
                     // self.update_session_config(cx);
                 }
@@ -1082,7 +1083,7 @@ impl Realtime {
                     // Update recording state based on interruption settings
                     if self.conversation_active {
                         let interruptions_enabled =
-                            self.check_box(id!(toggle_interruptions)).active(cx);
+                            self.check_box(ids!(toggle_interruptions)).active(cx);
 
                         if !interruptions_enabled {
                             // Interruptions disabled - mute microphone during AI speech
@@ -1093,7 +1094,7 @@ impl Realtime {
                         }
                     }
 
-                    self.label(id!(status_label))
+                    self.label(ids!(status_label))
                         .set_text(cx, "🔊 Playing audio...");
                 }
                 RealtimeEvent::AudioTranscript(text) => {
@@ -1128,7 +1129,7 @@ impl Realtime {
                     }
                 }
                 RealtimeEvent::SpeechStarted => {
-                    self.label(id!(status_label))
+                    self.label(ids!(status_label))
                         .set_text(cx, "🎤 User speech detected");
 
                     self.user_is_interrupting = true;
@@ -1158,7 +1159,7 @@ impl Realtime {
                     }
                 }
                 RealtimeEvent::SpeechStopped => {
-                    self.label(id!(status_label)).set_text(cx, "Processing...");
+                    self.label(ids!(status_label)).set_text(cx, "Processing...");
 
                     // Temporarily stop recording while waiting for response
                     if self.conversation_active {
@@ -1166,7 +1167,7 @@ impl Realtime {
                     }
                 }
                 RealtimeEvent::ResponseCompleted => {
-                    let status_label = self.label(id!(status_label));
+                    let status_label = self.label(ids!(status_label));
                     self.user_is_interrupting = false;
                     self.ai_is_responding = false;
                     self.current_assistant_item_id = None;
@@ -1175,7 +1176,7 @@ impl Realtime {
                     if self.conversation_active {
                         // Check if interruptions are enabled via the toggle
                         let interruptions_enabled =
-                            self.check_box(id!(toggle_interruptions)).active(cx);
+                            self.check_box(ids!(toggle_interruptions)).active(cx);
 
                         if interruptions_enabled {
                             // Allow immediate interruption
@@ -1220,14 +1221,14 @@ impl Realtime {
                         // Auto-approve function calls in dangerous mode
                         use crate::mcp::mcp_manager::display_name_from_namespaced;
                         let display_name = display_name_from_namespaced(&name);
-                        self.label(id!(status_label))
+                        self.label(ids!(status_label))
                             .set_text(cx, &format!("🔧 Auto-executing tool: {}", display_name));
 
                         // Execute the function call directly
                         self.handle_function_call(cx, name, call_id, arguments);
                     } else {
                         // Show permission request as usual
-                        self.label(id!(status_label))
+                        self.label(ids!(status_label))
                             .set_text(cx, &format!("🔧 Tool permission requested: {}", name));
 
                         self.show_tool_permission_request(cx, name, call_id, arguments);
@@ -1256,7 +1257,7 @@ impl Realtime {
                         );
                     } else {
                         // Other types of errors - just display them
-                        self.label(id!(status_label))
+                        self.label(ids!(status_label))
                             .set_text(cx, &format!("❌ Error: {}", error));
 
                         // Resume recording on non-connection errors
@@ -1280,19 +1281,19 @@ impl Realtime {
 
         self.pending_tool_call = Some((name.clone(), call_id, arguments));
 
-        let tool_line = self.view(id!(tool_permission_line));
+        let tool_line = self.view(ids!(tool_permission_line));
         tool_line.set_visible(cx, true);
 
         // Configure the tool line
         let display_name = display_name_from_namespaced(&name);
 
         tool_line
-            .avatar(id!(message_section.sender.avatar))
+            .avatar(ids!(message_section.sender.avatar))
             .borrow_mut()
             .unwrap()
             .avatar = Some(crate::protocol::Picture::Grapheme("T".into()));
         tool_line
-            .label(id!(message_section.sender.name))
+            .label(ids!(message_section.sender.name))
             .set_text(cx, "Permission Request");
 
         let content = crate::protocol::MessageContent {
@@ -1300,13 +1301,13 @@ impl Realtime {
             ..Default::default()
         };
         tool_line
-            .slot(id!(message_section.content_section.content))
+            .slot(ids!(message_section.content_section.content))
             .current()
             .as_standard_message_content()
             .set_content(cx, &content);
 
         tool_line
-            .view(id!(message_section.content_section.tool_actions))
+            .view(ids!(message_section.content_section.tool_actions))
             .set_visible(cx, true);
 
         // Pause recording while waiting for permission
@@ -1406,12 +1407,12 @@ impl Realtime {
     fn approve_tool_call(&mut self, cx: &mut Cx) {
         if let Some((name, call_id, arguments)) = self.pending_tool_call.take() {
             // Hide permission UI
-            self.view(id!(tool_permission_line)).set_visible(cx, false);
+            self.view(ids!(tool_permission_line)).set_visible(cx, false);
 
             // Update status
             use crate::mcp::mcp_manager::display_name_from_namespaced;
             let display_name = display_name_from_namespaced(&name);
-            self.label(id!(status_label))
+            self.label(ids!(status_label))
                 .set_text(cx, &format!("🔧 Executing tool: {}", display_name));
 
             // Execute the tool
@@ -1429,7 +1430,7 @@ impl Realtime {
     fn deny_tool_call(&mut self, cx: &mut Cx) {
         if let Some((name, call_id, _arguments)) = self.pending_tool_call.take() {
             // Hide permission UI
-            self.view(id!(tool_permission_line)).set_visible(cx, false);
+            self.view(ids!(tool_permission_line)).set_visible(cx, false);
 
             // Send denial response
             if let Some(channel) = &self.realtime_channel {
@@ -1448,7 +1449,7 @@ impl Realtime {
             // Update status
             use crate::mcp::mcp_manager::display_name_from_namespaced;
             let display_name = display_name_from_namespaced(&name);
-            self.label(id!(status_label))
+            self.label(ids!(status_label))
                 .set_text(cx, &format!("🚫 Tool '{}' denied", display_name));
 
             // Resume recording if conversation is active
@@ -1623,11 +1624,11 @@ impl Realtime {
     }
 
     fn update_session_config(&mut self, cx: &mut Cx) {
-        self.selected_voice = self.drop_down(id!(voice_selector)).selected_label();
-        self.view(id!(voice_selector_wrapper))
+        self.selected_voice = self.drop_down(ids!(voice_selector)).selected_label();
+        self.view(ids!(voice_selector_wrapper))
             .set_visible(cx, false);
-        self.view(id!(selected_voice_view)).set_visible(cx, true);
-        self.label(id!(selected_voice)).set_text(
+        self.view(ids!(selected_voice_view)).set_visible(cx, true);
+        self.label(ids!(selected_voice)).set_text(
             cx,
             format!("Selected voice: {}", self.selected_voice).as_str(),
         );
@@ -1639,7 +1640,7 @@ impl Realtime {
                 .unbounded_send(RealtimeCommand::UpdateSessionConfig {
                     voice: self.selected_voice.clone(),
                     transcription_model: self
-                        .drop_down(id!(transcription_model_selector))
+                        .drop_down(ids!(transcription_model_selector))
                         .selected_label(),
                 });
         }
@@ -1656,10 +1657,10 @@ impl Realtime {
 
     fn update_ui(&self, cx: &mut Cx) {
         if !self.conversation_active {
-            self.label(id!(stop_start_label))
+            self.label(ids!(stop_start_label))
                 .set_text(cx, "Start conversation");
         } else {
-            self.label(id!(stop_start_label))
+            self.label(ids!(stop_start_label))
                 .set_text(cx, "Stop conversation");
         }
     }

--- a/moly-kit/src/widgets/standard_message_content.rs
+++ b/moly-kit/src/widgets/standard_message_content.rs
@@ -62,11 +62,11 @@ impl StandardMessageContent {
         /// String to add as suffix to the message text when its being typed.
         const TYPING_INDICATOR: &str = "●";
 
-        let citation_list = self.citation_list(id!(citations));
+        let citation_list = self.citation_list(ids!(citations));
         citation_list.borrow_mut().unwrap().urls = content.citations.clone();
         citation_list.borrow_mut().unwrap().visible = !content.citations.is_empty();
 
-        let mut attachments = self.attachment_list(id!(attachments));
+        let mut attachments = self.attachment_list(ids!(attachments));
         attachments.write().attachments = content.attachments.clone();
 
         let ui = self.ui_runner();
@@ -74,7 +74,7 @@ impl StandardMessageContent {
             if let Some(attachment) = list.attachments.get(index).cloned() {
                 if crate::widgets::attachment_view::can_preview(&attachment) {
                     ui.defer(move |me, cx, _| {
-                        let modal = me.attachment_viewer_modal(id!(attachment_viewer_modal));
+                        let modal = me.attachment_viewer_modal(ids!(attachment_viewer_modal));
                         modal.borrow_mut().unwrap().open(cx, attachment);
                     });
                 } else {
@@ -83,12 +83,12 @@ impl StandardMessageContent {
             }
         });
 
-        self.message_thinking_block(id!(thinking_block))
+        self.message_thinking_block(ids!(thinking_block))
             .borrow_mut()
             .unwrap()
             .set_content(cx, content, metadata);
 
-        let markdown = self.label(id!(markdown));
+        let markdown = self.label(ids!(markdown));
 
         if metadata.is_writing() {
             let text_with_typing = format!("{} {}", content.text, TYPING_INDICATOR);

--- a/src/app.rs
+++ b/src/app.rs
@@ -247,7 +247,7 @@ impl AppMain for App {
 
         if let Event::Startup = event {
             // Prevent rendering the ui before the store is initialized.
-            self.ui.view(id!(body)).set_visible(cx, false);
+            self.ui.view(ids!(body)).set_visible(cx, false);
             register_capture_manager();
 
             #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -273,7 +273,7 @@ impl AppMain for App {
             return;
         };
 
-        self.ui.view(id!(loading_view)).set_visible(cx, false);
+        self.ui.view(ids!(loading_view)).set_visible(cx, false);
 
         // It triggers when the timer expires.
         if self.timer.is_event(event).is_some() {
@@ -301,26 +301,26 @@ impl MatchEvent for App {
         // Only show the MCP tab in native builds
         #[cfg(not(target_arch = "wasm32"))]
         {
-            radio_button_set = self.ui.radio_button_set(ids!(
+            radio_button_set = self.ui.radio_button_set(ids_array!(
                 sidebar_menu.chat_tab,
                 sidebar_menu.moly_server_tab,
                 sidebar_menu.mcp_tab,
                 sidebar_menu.providers_tab,
             ));
             self.ui
-                .view(id!(sidebar_menu.mcp_tab_container))
+                .view(ids!(sidebar_menu.mcp_tab_container))
                 .set_visible(cx, true);
         }
 
         #[cfg(target_arch = "wasm32")]
         {
-            radio_button_set = self.ui.radio_button_set(ids!(
+            radio_button_set = self.ui.radio_button_set(ids_array!(
                 sidebar_menu.chat_tab,
                 sidebar_menu.moly_server_tab,
                 sidebar_menu.providers_tab,
             ));
             self.ui
-                .view(id!(sidebar_menu.mcp_tab_container))
+                .view(ids!(sidebar_menu.mcp_tab_container))
                 .set_visible(cx, false);
         }
 
@@ -397,18 +397,18 @@ impl MatchEvent for App {
             }
 
             if let ChatAction::Start(_) = action.cast() {
-                let chat_radio_button = self.ui.radio_button(id!(chat_tab));
+                let chat_radio_button = self.ui.radio_button(ids!(chat_tab));
                 chat_radio_button.select(cx, &mut Scope::empty());
             }
 
             if let NavigationAction::NavigateToMyModels = action.cast() {
-                let my_models_radio_button = self.ui.radio_button(id!(my_models_tab));
+                let my_models_radio_button = self.ui.radio_button(ids!(my_models_tab));
                 my_models_radio_button.select(cx, &mut Scope::empty());
                 // navigate_to_my_models = true;
             }
 
             if let NavigationAction::NavigateToProviders = action.cast() {
-                let providers_radio_button = self.ui.radio_button(id!(providers_tab));
+                let providers_radio_button = self.ui.radio_button(ids!(providers_tab));
                 providers_radio_button.select(cx, &mut Scope::empty());
                 navigate_to_providers = true;
             }
@@ -422,27 +422,29 @@ impl MatchEvent for App {
                 DownloadNotificationPopupAction::ActionLinkClicked
                     | DownloadNotificationPopupAction::CloseButtonClicked
             ) {
-                self.ui.popup_notification(id!(download_popup)).close(cx);
+                self.ui.popup_notification(ids!(download_popup)).close(cx);
             }
 
             if let MolyClientAction::ServerUnreachable = action.cast() {
-                self.ui.popup_notification(id!(moly_server_popup)).open(cx);
+                self.ui.popup_notification(ids!(moly_server_popup)).open(cx);
             }
 
             if let MolyServerPopupAction::CloseButtonClicked = action.cast() {
-                self.ui.popup_notification(id!(moly_server_popup)).close(cx);
+                self.ui
+                    .popup_notification(ids!(moly_server_popup))
+                    .close(cx);
             }
         }
 
         // Handle navigation after processing all actions
         if navigate_to_providers {
-            self.navigate_to(cx, id!(application_pages.providers_frame));
+            self.navigate_to(cx, ids!(application_pages.providers_frame));
         } else if navigate_to_chat {
-            self.navigate_to(cx, id!(application_pages.chat_frame));
+            self.navigate_to(cx, ids!(application_pages.chat_frame));
         } else if navigate_to_moly_server {
-            self.navigate_to(cx, id!(application_pages.moly_server_frame));
+            self.navigate_to(cx, ids!(application_pages.moly_server_frame));
         } else if navigate_to_mcp {
-            self.navigate_to(cx, id!(application_pages.mcp_frame));
+            self.navigate_to(cx, ids!(application_pages.mcp_frame));
         }
     }
 }
@@ -453,7 +455,7 @@ impl App {
         if let Some(notification) = store.downloads.next_download_notification() {
             let mut popup = self
                 .ui
-                .download_notification_popup(id!(popup_download_notification));
+                .download_notification_popup(ids!(popup_download_notification));
 
             match notification {
                 DownloadPendingNotification::DownloadedFile(file) => {
@@ -466,7 +468,7 @@ impl App {
                 }
             }
 
-            self.ui.popup_notification(id!(download_popup)).open(cx);
+            self.ui.popup_notification(ids!(download_popup)).open(cx);
         }
     }
 
@@ -500,10 +502,10 @@ impl App {
     }
 
     fn navigate_to(&mut self, cx: &mut Cx, id: &[LiveId]) {
-        let providers_id = id!(application_pages.providers_frame);
-        let chat_id = id!(application_pages.chat_frame);
-        let moly_server_id = id!(application_pages.moly_server_frame);
-        let mcp_id = id!(application_pages.mcp_frame);
+        let providers_id = ids!(application_pages.providers_frame);
+        let chat_id = ids!(application_pages.chat_frame);
+        let moly_server_id = ids!(application_pages.moly_server_frame);
+        let mcp_id = ids!(application_pages.mcp_frame);
 
         if id != providers_id {
             self.ui.widget(providers_id).set_visible(cx, false);

--- a/src/chat/chat_history.rs
+++ b/src/chat/chat_history.rs
@@ -148,7 +148,7 @@ impl Widget for ChatHistory {
 impl WidgetMatchEvent for ChatHistory {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let clicked_entity_button = self
-            .portal_list(id!(list))
+            .portal_list(ids!(list))
             .items_with_actions(actions)
             .iter()
             .map(|(_, item)| item.as_entity_button())

--- a/src/chat/chat_history_card.rs
+++ b/src/chat/chat_history_card.rs
@@ -305,7 +305,7 @@ impl Widget for ChatHistoryCard {
             .unwrap();
 
         if let Some(current_chat_id) = store.chats.get_current_chat_id() {
-            let content_view_highlight = self.view(id!(selected_bg));
+            let content_view_highlight = self.view(ids!(selected_bg));
 
             if current_chat_id == self.chat_id {
                 content_view_highlight.apply_over(
@@ -316,7 +316,7 @@ impl Widget for ChatHistoryCard {
                 );
             } else {
                 if chat.borrow().has_unread_messages {
-                    self.view(id!(unread_message_badge)).set_visible(cx, true);
+                    self.view(ids!(unread_message_badge)).set_visible(cx, true);
                 }
                 content_view_highlight.apply_over(
                     cx,
@@ -355,18 +355,18 @@ impl WidgetMatchEvent for ChatHistoryCard {
             TitleState::OnEdit => self.handle_title_on_edit_actions(cx, actions, scope),
         }
 
-        let chat_options_wrapper_rect = self.view(id!(chat_options_wrapper)).area().rect(cx);
-        if self.button(id!(chat_options)).clicked(actions) {
+        let chat_options_wrapper_rect = self.view(ids!(chat_options_wrapper)).area().rect(cx);
+        if self.button(ids!(chat_options)).clicked(actions) {
             let wrapper_coords = chat_options_wrapper_rect.pos;
             let coords = dvec2(
                 wrapper_coords.x - 100.,
                 wrapper_coords.y + chat_options_wrapper_rect.size.y - 12.0,
             );
 
-            self.chat_history_card_options(id!(chat_history_card_options))
+            self.chat_history_card_options(ids!(chat_history_card_options))
                 .selected(cx, self.chat_id);
 
-            let modal = self.modal(id!(chat_history_card_options_modal));
+            let modal = self.modal(ids!(chat_history_card_options_modal));
             modal.apply_over(
                 cx,
                 live! {
@@ -377,14 +377,14 @@ impl WidgetMatchEvent for ChatHistoryCard {
             return;
         }
 
-        if let Some(fe) = self.view(id!(content)).finger_down(actions) {
+        if let Some(fe) = self.view(ids!(content)).finger_down(actions) {
             if fe.tap_count == 1 {
                 let store = scope.data.get_mut::<Store>().unwrap();
                 store.chats.set_current_chat(Some(self.chat_id));
 
                 if let Some(chat) = store.chats.get_chat_by_id(self.chat_id) {
                     chat.borrow_mut().has_unread_messages = false;
-                    self.view(id!(unread_message_badge)).set_visible(cx, false);
+                    self.view(ids!(unread_message_badge)).set_visible(cx, false);
                 }
 
                 cx.action(ChatAction::ChatSelected(self.chat_id));
@@ -399,7 +399,7 @@ impl WidgetMatchEvent for ChatHistoryCard {
                     | DeleteChatModalAction::CloseButtonClicked
                     | DeleteChatModalAction::ChatDeleted
             ) {
-                self.modal(id!(delete_chat_modal)).close(cx);
+                self.modal(ids!(delete_chat_modal)).close(cx);
             }
         }
     }
@@ -414,25 +414,25 @@ impl ChatHistoryCard {
     }
 
     fn set_title_text(&mut self, cx: &mut Cx, text: &str, caption: &str) {
-        self.view.label(id!(title_label)).set_text(cx, text.trim());
+        self.view.label(ids!(title_label)).set_text(cx, text.trim());
         if let TitleState::Editable = self.title_edition_state {
             self.view
-                .text_input(id!(title_input))
+                .text_input(ids!(title_input))
                 .set_text(cx, &text.trim());
         }
-        self.label(id!(model_or_agent_name_label))
+        self.label(ids!(model_or_agent_name_label))
             .set_text(cx, &human_readable_name(caption));
     }
 
     fn update_title_visibility(&mut self, cx: &mut Cx) {
         let on_edit = matches!(self.title_edition_state, TitleState::OnEdit);
-        self.view(id!(edit_buttons)).set_visible(cx, on_edit);
-        self.view(id!(title_input_container))
+        self.view(ids!(edit_buttons)).set_visible(cx, on_edit);
+        self.view(ids!(title_input_container))
             .set_visible(cx, on_edit);
-        self.button(id!(chat_options)).set_visible(cx, !on_edit);
+        self.button(ids!(chat_options)).set_visible(cx, !on_edit);
 
         let editable = matches!(self.title_edition_state, TitleState::Editable);
-        self.view(id!(title_label_container))
+        self.view(ids!(title_label_container))
             .set_visible(cx, editable);
     }
 
@@ -466,8 +466,8 @@ impl ChatHistoryCard {
             match action.cast() {
                 ChatHistoryCardAction::MenuClosed(chat_id) => {
                     if chat_id == self.chat_id {
-                        self.button(id!(chat_options)).reset_hover(cx);
-                        self.modal(id!(chat_history_card_options_modal)).close(cx);
+                        self.button(ids!(chat_options)).reset_hover(cx);
+                        self.modal(ids!(chat_history_card_options_modal)).close(cx);
                     }
                 }
                 ChatHistoryCardAction::ActivateTitleEdition(chat_id) => {
@@ -478,10 +478,10 @@ impl ChatHistoryCard {
                 ChatHistoryCardAction::DeleteChatOptionSelected(chat_id) => {
                     if chat_id == self.chat_id {
                         let mut delete_modal_inner =
-                            self.delete_chat_modal(id!(delete_chat_modal_inner));
+                            self.delete_chat_modal(ids!(delete_chat_modal_inner));
                         delete_modal_inner.set_chat_id(self.chat_id);
 
-                        self.modal(id!(delete_chat_modal)).open(cx);
+                        self.modal(ids!(delete_chat_modal)).open(cx);
                     }
                 }
                 _ => {}
@@ -490,10 +490,10 @@ impl ChatHistoryCard {
             // If the modal is dissmised (such as, clicking outside) we need to reset the hover state
             // of the open chat options button.
             if self
-                .modal(id!(chat_history_card_options_modal))
+                .modal(ids!(chat_history_card_options_modal))
                 .dismissed(actions)
             {
-                self.button(id!(chat_options)).reset_hover(cx);
+                self.button(ids!(chat_options)).reset_hover(cx);
             }
         }
     }
@@ -501,8 +501,8 @@ impl ChatHistoryCard {
     fn handle_title_on_edit_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
 
-        if self.button(id!(save)).clicked(actions) {
-            let updated_title = self.text_input(id!(title_input)).text();
+        if self.button(ids!(save)).clicked(actions) {
+            let updated_title = self.text_input(ids!(title_input)).text();
             let chat = store
                 .chats
                 .saved_chats
@@ -518,7 +518,7 @@ impl ChatHistoryCard {
             self.transition_title_state(cx)
         }
 
-        if let Some((val, _)) = self.text_input(id!(title_input)).returned(actions) {
+        if let Some((val, _)) = self.text_input(ids!(title_input)).returned(actions) {
             let chat = store
                 .chats
                 .saved_chats
@@ -534,7 +534,7 @@ impl ChatHistoryCard {
             self.transition_title_state(cx)
         }
 
-        if self.button(id!(cancel)).clicked(actions) {
+        if self.button(ids!(cancel)).clicked(actions) {
             self.transition_title_state(cx)
         }
     }

--- a/src/chat/chat_history_card_options.rs
+++ b/src/chat/chat_history_card_options.rs
@@ -127,7 +127,7 @@ impl ChatHistoryCardOptionsRef {
 
 impl WidgetMatchEvent for ChatHistoryCardOptions {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(delete_chat)).clicked(actions) {
+        if self.button(ids!(delete_chat)).clicked(actions) {
             cx.action(ChatHistoryCardAction::MenuClosed(self.chat_id));
 
             cx.action(ChatHistoryCardAction::DeleteChatOptionSelected(
@@ -135,7 +135,7 @@ impl WidgetMatchEvent for ChatHistoryCardOptions {
             ));
         }
 
-        if self.button(id!(edit_chat_name)).clicked(actions) {
+        if self.button(ids!(edit_chat_name)).clicked(actions) {
             cx.action(ChatHistoryCardAction::MenuClosed(self.chat_id));
 
             cx.action(ChatHistoryCardAction::ActivateTitleEdition(self.chat_id));

--- a/src/chat/chat_history_panel.rs
+++ b/src/chat/chat_history_panel.rs
@@ -86,7 +86,7 @@ impl Widget for ChatHistoryPanel {
 
 impl WidgetMatchEvent for ChatHistoryPanel {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(new_chat_button)).clicked(&actions) {
+        if self.button(ids!(new_chat_button)).clicked(&actions) {
             cx.action(ChatAction::StartWithoutEntity);
             self.redraw(cx);
         }

--- a/src/chat/chat_params.rs
+++ b/src/chat/chat_params.rs
@@ -260,15 +260,15 @@ impl Widget for ChatParams {
             let chat = chat.borrow();
             let ip = &chat.inferences_params;
 
-            let temperature = self.slider(id!(temperature));
-            let top_p = self.slider(id!(top_p));
-            let max_tokens = self.slider(id!(max_tokens));
-            let frequency_penalty = self.slider(id!(frequency_penalty));
-            let presence_penalty = self.slider(id!(presence_penalty));
-            let stop = self.text_input(id!(stop));
-            let stream = self.check_box(id!(stream));
+            let temperature = self.slider(ids!(temperature));
+            let top_p = self.slider(ids!(top_p));
+            let max_tokens = self.slider(ids!(max_tokens));
+            let frequency_penalty = self.slider(ids!(frequency_penalty));
+            let presence_penalty = self.slider(ids!(presence_penalty));
+            let stop = self.text_input(ids!(stop));
+            let stream = self.check_box(ids!(stream));
 
-            let system_prompt = self.text_input(id!(system_prompt));
+            let system_prompt = self.text_input(ids!(system_prompt));
 
             temperature.set_value(cx, ip.temperature.into());
             top_p.set_value(cx, ip.top_p.into());
@@ -310,35 +310,35 @@ impl WidgetMatchEvent for ChatParams {
 
             let ip = &mut chat.inferences_params;
 
-            if let Some(value) = self.slider(id!(temperature)).slided(&actions) {
+            if let Some(value) = self.slider(ids!(temperature)).slided(&actions) {
                 ip.temperature = value as f32;
             }
 
-            if let Some(value) = self.slider(id!(top_p)).slided(&actions) {
+            if let Some(value) = self.slider(ids!(top_p)).slided(&actions) {
                 ip.top_p = value as f32;
             }
 
-            if let Some(value) = self.slider(id!(max_tokens)).slided(&actions) {
+            if let Some(value) = self.slider(ids!(max_tokens)).slided(&actions) {
                 ip.max_tokens = value as u32;
             }
 
-            if let Some(value) = self.slider(id!(frequency_penalty)).slided(&actions) {
+            if let Some(value) = self.slider(ids!(frequency_penalty)).slided(&actions) {
                 ip.frequency_penalty = value as f32;
             }
 
-            if let Some(value) = self.slider(id!(presence_penalty)).slided(&actions) {
+            if let Some(value) = self.slider(ids!(presence_penalty)).slided(&actions) {
                 ip.presence_penalty = value as f32;
             }
 
-            if let Some(value) = self.text_input(id!(stop)).changed(&actions) {
+            if let Some(value) = self.text_input(ids!(stop)).changed(&actions) {
                 ip.stop = value;
             }
 
-            if let Some(value) = self.check_box(id!(stream)).changed(actions) {
+            if let Some(value) = self.check_box(ids!(stream)).changed(actions) {
                 ip.stream = value;
             }
 
-            if let Some(value) = self.text_input(id!(system_prompt)).changed(&actions) {
+            if let Some(value) = self.text_input(ids!(system_prompt)).changed(&actions) {
                 if value.is_empty() {
                     chat.system_prompt = None;
                 } else {
@@ -356,56 +356,56 @@ impl ChatParams {
         }
 
         self.handle_tooltip_actions_for_label(
-            id!(system_prompt_label),
+            ids!(system_prompt_label),
             "A system prompt is a fixed prompt providing context and instructions to the model. The system prompt is always included in the provided input to the LLM, regardless of the user prompt.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_slider(
-            id!(temperature),
+            ids!(temperature),
             "Influences the randomness of the model’s output. A higher value leads to more random and diverse responses, while a lower value produces more predictable outputs.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_slider(
-            id!(top_p),
+            ids!(top_p),
             "Top P, also known as nucleus sampling, is another parameter that influences the randomness of LLM output. This parameter determines the threshold probability for including tokens in a candidate set used by the LLM to generate output. Lower values of this parameter result in more precise and fact-based responses from the LLM, while higher values increase randomness and diversity in the generated output.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_label(
-            id!(stream_label),
+            ids!(stream_label),
             "Streaming is the sending of words as they are created by the AI language model one at a time, so you can show them as they are being generated.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_slider(
-            id!(max_tokens),
+            ids!(max_tokens),
             "The max tokens parameter sets the upper limit for the total number of tokens, encompassing both the input provided to the LLM as a prompt and the output tokens generated by the LLM in response to that prompt.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_label(
-            id!(stop_label),
+            ids!(stop_label),
             "Stop sequences are used to make the model stop generating tokens at a desired point, such as the end of a sentence or a list. The model response will not contain the stop sequence and you can pass up to four stop sequences.".to_string(),
             TOOLTIP_OFFSET,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_slider(
-            id!(frequency_penalty),
+            ids!(frequency_penalty),
             "This parameter is used to discourage the model from repeating the same words or phrases too frequently within the generated text. It is a value that is added to the log-probability of a token each time it occurs in the generated text. A higher frequency_penalty value will result in the model being more conservative in its use of repeated tokens.".to_string(),
             TOOLTIP_OFFSET_BOTTOM,
             cx, actions
         );
 
         self.handle_tooltip_actions_for_slider(
-            id!(presence_penalty),
+            ids!(presence_penalty),
             "This parameter is used to encourage the model to include a diverse range of tokens in the generated text. It is a value that is subtracted from the log-probability of a token each time it is generated. A higher presence_penalty value will result in the model being more likely to generate tokens that have not yet been included in the generated text.".to_string(),
             TOOLTIP_OFFSET_BOTTOM,
             cx, actions
@@ -421,7 +421,7 @@ impl ChatParams {
         actions: &Actions,
     ) {
         let slider = self.slider(slider_id);
-        let mut tooltip = self.deref.tooltip(id!(tooltip));
+        let mut tooltip = self.deref.tooltip(ids!(tooltip));
 
         if let Some(rect) = slider.label_hover_in(&actions) {
             tooltip.show_with_options(cx, rect.pos + offset, &text);
@@ -440,7 +440,7 @@ impl ChatParams {
         actions: &Actions,
     ) {
         let label = self.label(label_id);
-        let mut tooltip = self.deref.tooltip(id!(tooltip));
+        let mut tooltip = self.deref.tooltip(ids!(tooltip));
 
         if let Some(rect) = label.hover_in(&actions) {
             tooltip.show_with_options(cx, rect.pos + offset, &text);

--- a/src/chat/chat_screen.rs
+++ b/src/chat/chat_screen.rs
@@ -97,20 +97,20 @@ impl Widget for ChatScreen {
 
 impl WidgetMatchEvent for ChatScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(new_chat_button)).clicked(&actions) {
+        if self.button(ids!(new_chat_button)).clicked(&actions) {
             cx.action(ChatAction::StartWithoutEntity);
-            self.stack_navigation(id!(navigation)).pop_to_root(cx);
+            self.stack_navigation(ids!(navigation)).pop_to_root(cx);
             self.redraw(cx);
         }
 
         for action in actions {
             if let ChatAction::ChatSelected(_chat_id) = action.cast() {
-                self.stack_navigation(id!(navigation)).pop_to_root(cx);
+                self.stack_navigation(ids!(navigation)).pop_to_root(cx);
                 self.redraw(cx);
             }
 
             if let ConnectionSettingsAction::ProviderSelected(provider_id) = action.cast() {
-                self.stack_navigation(id!(navigation))
+                self.stack_navigation(ids!(navigation))
                     .push(cx, live_id!(provider_navigation_view));
 
                 let provider = scope
@@ -122,7 +122,7 @@ impl WidgetMatchEvent for ChatScreen {
                     .get(&provider_id);
                 if let Some(provider) = provider {
                     self.view
-                        .provider_view(id!(provider_view))
+                        .provider_view(ids!(provider_view))
                         .set_provider(cx, provider);
                 } else {
                     eprintln!("Provider not found: {}", provider_id);

--- a/src/chat/chat_screen_mobile.rs
+++ b/src/chat/chat_screen_mobile.rs
@@ -261,27 +261,27 @@ impl Widget for ChatScreenMobile {
 
 impl WidgetMatchEvent for ChatScreenMobile {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        let stack_navigation = self.stack_navigation(id!(navigation));
+        let stack_navigation = self.stack_navigation(ids!(navigation));
         stack_navigation.handle_stack_view_actions(cx, actions);
 
         // Menu Toggle
-        if let Some(_evt) = self.view(id!(menu_toggle)).finger_down(actions) {
+        if let Some(_evt) = self.view(ids!(menu_toggle)).finger_down(actions) {
             stack_navigation.push(cx, live_id!(history_navigation_view));
         }
 
-        let modal = self.moly_modal(id!(settings_menu));
+        let modal = self.moly_modal(ids!(settings_menu));
 
         // Settings Menu
-        if let Some(_evt) = self.view(id!(settings_button)).finger_down(actions) {
+        if let Some(_evt) = self.view(ids!(settings_button)).finger_down(actions) {
             // TODO: Ideally we should use the settings_button position but for some reason is always coming back fixed at 100.0
             let parent_view_width = self
-                .stack_navigation_view(id!(history_navigation_view))
+                .stack_navigation_view(ids!(history_navigation_view))
                 .area()
                 .rect(cx)
                 .size
                 .x;
 
-            let button_rect = self.view(id!(settings_button)).area().rect(cx);
+            let button_rect = self.view(ids!(settings_button)).area().rect(cx);
             let coords = dvec2(
                 parent_view_width - 170.0,
                 button_rect.pos.y + button_rect.size.y,
@@ -297,13 +297,13 @@ impl WidgetMatchEvent for ChatScreenMobile {
         }
 
         // Go to Providers
-        if let Some(_evt) = self.view(id!(go_to_providers)).finger_down(actions) {
+        if let Some(_evt) = self.view(ids!(go_to_providers)).finger_down(actions) {
             modal.close(cx);
             stack_navigation.push(cx, live_id!(providers_navigation_view));
         }
 
         // Go to MCP Servers
-        if let Some(_evt) = self.view(id!(go_to_mcp)).finger_down(actions) {
+        if let Some(_evt) = self.view(ids!(go_to_mcp)).finger_down(actions) {
             modal.close(cx);
             stack_navigation.push(cx, live_id!(mcp_navigation_view));
         }

--- a/src/chat/chat_view.rs
+++ b/src/chat/chat_view.rs
@@ -153,7 +153,7 @@ pub struct ChatView {
 
 impl LiveHook for ChatView {
     fn after_new_from_doc(&mut self, cx: &mut Cx) {
-        self.prompt_input(id!(chat.prompt)).write().disable();
+        self.prompt_input(ids!(chat.prompt)).write().disable();
         let plugin_id = self
             .chat_controller
             .lock()
@@ -161,7 +161,7 @@ impl LiveHook for ChatView {
             .append_plugin(Glue::new(self.ui_runner()));
         self.plugin_id = Some(plugin_id);
 
-        self.chat(id!(chat))
+        self.chat(ids!(chat))
             .write()
             .set_chat_controller(cx, Some(self.chat_controller.clone()));
     }
@@ -170,7 +170,7 @@ impl LiveHook for ChatView {
 impl Drop for ChatView {
     fn drop(&mut self) {
         if let Some(plugin_id) = self.plugin_id.take() {
-            self.chat(id!(chat))
+            self.chat(ids!(chat))
                 .write()
                 .chat_controller()
                 .as_ref()
@@ -202,7 +202,7 @@ impl Widget for ChatView {
         // On mobile, only set padding on top of the prompt
         // TODO: do this with AdaptiveView instead of apply_over
         if !cx.display_context.is_desktop() && cx.display_context.is_screen_size_known() {
-            self.prompt_input(id!(chat.prompt)).apply_over(
+            self.prompt_input(ids!(chat.prompt)).apply_over(
                 cx,
                 live! {
                     padding: {bottom: 50, left: 20, right: 20}
@@ -211,7 +211,7 @@ impl Widget for ChatView {
                     }
                 },
             );
-            self.model_selector(id!(model_selector)).apply_over(
+            self.model_selector(ids!(model_selector)).apply_over(
                 cx,
                 live! {
                     width: Fill
@@ -219,7 +219,7 @@ impl Widget for ChatView {
                 },
             );
         } else {
-            self.prompt_input(id!(chat.prompt)).apply_over(
+            self.prompt_input(ids!(chat.prompt)).apply_over(
                 cx,
                 live! {
                     padding: {left: 10, right: 10, top: 8, bottom: 8}
@@ -228,7 +228,7 @@ impl Widget for ChatView {
                     }
                 },
             );
-            self.model_selector(id!(model_selector)).apply_over(
+            self.model_selector(ids!(model_selector)).apply_over(
                 cx,
                 live! {
                     width: Fit
@@ -244,7 +244,7 @@ impl Widget for ChatView {
 impl WidgetMatchEvent for ChatView {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
-        let mut chat_widget = self.chat(id!(chat));
+        let mut chat_widget = self.chat(ids!(chat));
 
         for action in actions {
             // Handle model selector actions
@@ -286,14 +286,14 @@ impl ChatView {
             }
         }
 
-        let mut chat = self.chat(id!(chat));
-        let mut prompt_input = self.prompt_input(id!(chat.prompt));
+        let mut chat = self.chat(ids!(chat));
+        let mut prompt_input = self.prompt_input(ids!(chat.prompt));
 
         // If the bot is not available and we know it won't be available soon, clear the bot_id in the chat widget
         if !bot_available && store.provider_syncing_status == ProviderSyncingStatus::Synced {
             chat.write().set_bot_id(cx, None);
 
-            self.model_selector(id!(model_selector))
+            self.model_selector(ids!(model_selector))
                 .set_currently_selected_model(cx, None);
         } else if bot_available && chat.read().bot_id().is_none() {
             // If the bot is available and the chat widget doesn't have a bot_id, set the bot_id in the chat widget
@@ -318,7 +318,7 @@ impl ChatView {
         if self.message_updated_while_inactive {
             // If the message is done writing, and this chat view is not focused
             // set the chat as having unread messages (show a badge on the chat history card)
-            if !self.chat(id!(chat)).read().is_streaming() && !self.focused {
+            if !self.chat(ids!(chat)).read().is_streaming() && !self.focused {
                 if let Some(chat) = store.chats.get_chat_by_id(self.chat_id) {
                     chat.borrow_mut().has_unread_messages = true;
                     self.message_updated_while_inactive = false;
@@ -357,7 +357,7 @@ impl ChatViewRef {
         if let Some(mut inner) = self.borrow_mut() {
             inner.chat_id = chat_id;
             inner
-                .model_selector(id!(model_selector))
+                .model_selector(ids!(model_selector))
                 .set_chat_id(chat_id);
         }
     }
@@ -545,7 +545,7 @@ impl Glue {
 
             // Let's update the attachments back with the persisted key and reader.
             ui.defer(move |me, _cx, _scope| {
-                let chat = me.chat(id!(chat));
+                let chat = me.chat(ids!(chat));
                 let chat_controller = chat.read().chat_controller().expect("chat controller missing").clone();
                 let mut found = false;
 

--- a/src/chat/chats_deck.rs
+++ b/src/chat/chats_deck.rs
@@ -144,7 +144,7 @@ impl WidgetMatchEvent for ChatsDeck {
                     .get_mut(&self.currently_visible_chat_id.unwrap())
                 {
                     chat_view
-                        .prompt_input(id!(prompt))
+                        .prompt_input(ids!(prompt))
                         .write()
                         .set_text(cx, event.contents());
                 }
@@ -200,10 +200,10 @@ impl ChatsDeck {
         // Set associated bot
         if let Some(bot_id) = &chat_data.associated_bot {
             chat_view_to_update
-                .model_selector(id!(model_selector))
+                .model_selector(ids!(model_selector))
                 .set_currently_selected_model(cx, Some(bot_id.clone()));
             chat_view_to_update
-                .chat(id!(chat))
+                .chat(ids!(chat))
                 .write()
                 .set_bot_id(cx, Some(bot_id.clone()));
         }
@@ -227,7 +227,7 @@ impl ChatsDeck {
             if let Some(chat_view) = self.chat_view_refs.get_mut(&least_recently_used_chat_id) {
                 let mut should_remove = true;
                 // Check if the latest message is currently being streamed
-                if chat_view.chat(id!(chat)).read().is_streaming() {
+                if chat_view.chat(ids!(chat)).read().is_streaming() {
                     should_remove = false;
                 }
 

--- a/src/chat/delete_chat_modal.rs
+++ b/src/chat/delete_chat_modal.rs
@@ -170,7 +170,7 @@ impl Widget for DeleteChatModal {
             "Are you sure you want to delete {}?\nThis action cannot be undone.",
             chat_title
         );
-        self.label(id!(wrapper.body.delete_prompt))
+        self.label(ids!(wrapper.body.delete_prompt))
             .set_text(cx, &prompt_text);
 
         self.view
@@ -180,18 +180,18 @@ impl Widget for DeleteChatModal {
 
 impl WidgetMatchEvent for DeleteChatModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(DeleteChatModalAction::CloseButtonClicked);
         }
 
-        if self.button(id!(delete_button)).clicked(actions) {
+        if self.button(ids!(delete_button)).clicked(actions) {
             let store = scope.data.get_mut::<Store>().unwrap();
             store.delete_chat(self.chat_id);
             cx.action(DeleteChatModalAction::ChatDeleted);
             cx.redraw_all();
         }
 
-        if self.button(id!(cancel_button)).clicked(actions) {
+        if self.button(ids!(cancel_button)).clicked(actions) {
             cx.action(DeleteChatModalAction::Cancelled);
         }
     }

--- a/src/chat/entity_button.rs
+++ b/src/chat/entity_button.rs
@@ -140,7 +140,7 @@ impl Widget for EntityButton {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         if self.server_url_visible {
-            self.view(id!(server_url)).set_visible(cx, true);
+            self.view(ids!(server_url)).set_visible(cx, true);
         }
 
         if self.should_update_bot_info && self.bot_id.is_some() {
@@ -172,10 +172,10 @@ impl EntityButton {
         let store = scope.data.get_mut::<Store>().unwrap();
         self.visible = true;
 
-        let description_label = self.label(id!(description.label));
-        let name_label = self.label(id!(caption));
-        let mut avatar = self.chat_agent_avatar(id!(agent_avatar));
-        let server_url = self.label(id!(server_url.label));
+        let description_label = self.label(ids!(description.label));
+        let name_label = self.label(ids!(caption));
+        let mut avatar = self.chat_agent_avatar(ids!(agent_avatar));
+        let server_url = self.label(ids!(server_url.label));
 
         let bot = store.chats.get_bot_or_placeholder(&bot_id);
 
@@ -210,7 +210,7 @@ impl EntityButton {
     }
 
     pub fn set_description_visible(&mut self, cx: &mut Cx, visible: bool) {
-        self.view(id!(description)).set_visible(cx, visible);
+        self.view(ids!(description)).set_visible(cx, visible);
     }
 }
 

--- a/src/chat/model_selector.rs
+++ b/src/chat/model_selector.rs
@@ -262,7 +262,7 @@ impl Widget for ModelSelector {
         }
 
         if let Hit::FingerDown(fd) =
-            event.hits_with_capture_overload(cx, self.view(id!(button)).area(), true)
+            event.hits_with_capture_overload(cx, self.view(ids!(button)).area(), true)
         {
             let is_syncing = matches!(
                 store.provider_syncing_status,
@@ -272,14 +272,14 @@ impl Widget for ModelSelector {
                 self.open = !self.open;
 
                 if self.open {
-                    let button_rect = self.view(id!(button)).area().rect(cx);
+                    let button_rect = self.view(ids!(button)).area().rect(cx);
                     let coords = dvec2(
                         button_rect.pos.x - 5.0,
                         button_rect.pos.y + button_rect.size.y,
                     );
                     let modal_content_size = (button_rect.size.x + 10.0).max(360.0);
 
-                    let modal = self.modal(id!(bot_options_modal));
+                    let modal = self.modal(ids!(bot_options_modal));
                     modal.apply_over(
                         cx,
                         live! {
@@ -288,7 +288,7 @@ impl Widget for ModelSelector {
                     );
                     modal.open(cx);
 
-                    let list = self.model_selector_list(id!(list_container.list));
+                    let list = self.model_selector_list(ids!(list_container.list));
                     let height = list.get_height();
                     if height > MAX_OPTIONS_HEIGHT {
                         self.options_list_height = Some(MAX_OPTIONS_HEIGHT);
@@ -296,35 +296,35 @@ impl Widget for ModelSelector {
                         self.options_list_height = Some(height);
                     }
 
-                    self.view(id!(options)).apply_over(
+                    self.view(ids!(options)).apply_over(
                         cx,
                         live! {
                             height: Fit,
                         },
                     );
 
-                    self.animator_play(cx, id!(open.show));
+                    self.animator_play(cx, ids!(open.show));
                 } else {
                     self.hide_animation_timer = cx.start_timeout(0.3);
-                    self.animator_play(cx, id!(open.hide));
+                    self.animator_play(cx, ids!(open.hide));
                 }
             }
         }
 
         if self.hide_animation_timer.is_event(event).is_some() {
             // When closing animation is done, hide the wrapper element
-            self.view(id!(options)).apply_over(cx, live! { height: 0 });
+            self.view(ids!(options)).apply_over(cx, live! { height: 0 });
             self.redraw(cx);
         }
 
         if self.animator_handle_event(cx, event).must_redraw() {
             if let Some(total_height) = self.options_list_height {
                 let height = self.open_animation_progress * total_height;
-                self.view(id!(options.list_container))
+                self.view(ids!(options.list_container))
                     .apply_over(cx, live! {height: (height)});
 
                 let rotate_angle = self.rotate_animation_progress * std::f64::consts::PI;
-                self.view(id!(icon_drop.icon))
+                self.view(ids!(icon_drop.icon))
                     .apply_over(cx, live! {draw_bg: {rotation: (rotate_angle)}});
 
                 self.redraw(cx);
@@ -333,7 +333,7 @@ impl Widget for ModelSelector {
 
         // Trigger a redraw if the provider syncing status has changed
         if let ProviderSyncingStatus::Syncing(_syncing) = &store.provider_syncing_status {
-            self.model_selector_loading(id!(loading))
+            self.model_selector_loading(ids!(loading))
                 .show_and_animate(cx);
         }
     }
@@ -350,17 +350,17 @@ impl Widget for ModelSelector {
         // Handle syncing status
         match &syncing_status {
             ProviderSyncingStatus::Syncing(syncing) => {
-                self.model_selector_loading(id!(button.loading))
+                self.model_selector_loading(ids!(button.loading))
                     .show_and_animate(cx);
-                self.view(id!(choose)).set_visible(cx, true);
-                self.view(id!(icon_drop)).set_visible(cx, false);
-                self.view(id!(selected_bot)).set_visible(cx, false);
-                self.label(id!(choose.label)).set_text(
+                self.view(ids!(choose)).set_visible(cx, true);
+                self.view(ids!(icon_drop)).set_visible(cx, false);
+                self.view(ids!(selected_bot)).set_visible(cx, false);
+                self.label(ids!(choose.label)).set_text(
                     cx,
                     &format!("Syncing providers... {}/{}", syncing.current, syncing.total),
                 );
                 let color = vec3(0.0, 0.0, 0.0);
-                self.label(id!(choose.label)).apply_over(
+                self.label(ids!(choose.label)).apply_over(
                     cx,
                     live! {
                         draw_text: {
@@ -371,13 +371,13 @@ impl Widget for ModelSelector {
             }
             ProviderSyncingStatus::NotSyncing | ProviderSyncingStatus::Synced => {
                 // Just set the loading component to not visible since there's no hide method
-                self.view(id!(button.loading)).set_visible(cx, false);
+                self.view(ids!(button.loading)).set_visible(cx, false);
 
                 if self.currently_selected_model.is_none() {
-                    self.view(id!(choose)).set_visible(cx, true);
-                    self.view(id!(selected_bot)).set_visible(cx, false);
+                    self.view(ids!(choose)).set_visible(cx, true);
+                    self.view(ids!(selected_bot)).set_visible(cx, false);
                     let color = vec3(0.0, 0.0, 0.0);
-                    self.label(id!(choose.label)).apply_over(
+                    self.label(ids!(choose.label)).apply_over(
                         cx,
                         live! {
                             draw_text: {
@@ -388,13 +388,13 @@ impl Widget for ModelSelector {
 
                     // If there are available bots, prompt the user to choose an assistant
                     if !models.is_empty() {
-                        self.label(id!(choose.label))
+                        self.label(ids!(choose.label))
                             .set_text(cx, "Choose your AI assistant");
-                        self.view(id!(icon_drop)).set_visible(cx, true);
+                        self.view(ids!(icon_drop)).set_visible(cx, true);
                     } else {
-                        self.label(id!(choose.label))
+                        self.label(ids!(choose.label))
                             .set_text(cx, "No assistants available, check your provider settings");
-                        self.view(id!(icon_drop)).set_visible(cx, false);
+                        self.view(ids!(icon_drop)).set_visible(cx, false);
                     }
                 } else {
                     self.update_selected_model_info(cx, store);
@@ -412,8 +412,8 @@ impl WidgetMatchEvent for ModelSelector {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         let mut should_hide_options = false;
         for action in actions {
-            if let Some(text) = self.text_input(id!(options.search.input)).changed(actions) {
-                self.model_selector_list(id!(list_container.list))
+            if let Some(text) = self.text_input(ids!(options.search.input)).changed(actions) {
+                self.model_selector_list(ids!(list_container.list))
                     .set_search_filter(cx, &text);
             }
 
@@ -441,7 +441,7 @@ impl WidgetMatchEvent for ModelSelector {
                 _ => {}
             }
 
-            let modal = self.modal(id!(bot_options_modal));
+            let modal = self.modal(ids!(bot_options_modal));
             if modal.dismissed(actions) {
                 self.clear_search(cx);
             }
@@ -451,19 +451,19 @@ impl WidgetMatchEvent for ModelSelector {
 
 impl ModelSelector {
     fn clear_search(&mut self, cx: &mut Cx) {
-        self.model_selector_list(id!(list_container.list))
+        self.model_selector_list(ids!(list_container.list))
             .clear_search_filter(cx);
-        self.text_input(id!(options.search.input)).set_text(cx, "");
+        self.text_input(ids!(options.search.input)).set_text(cx, "");
         self.redraw(cx);
     }
 
     fn hide_options(&mut self, cx: &mut Cx) {
         self.open = false;
-        self.view(id!(options)).apply_over(cx, live! { height: 0 });
-        self.view(id!(icon_drop.icon))
+        self.view(ids!(options)).apply_over(cx, live! { height: 0 });
+        self.view(ids!(icon_drop.icon))
             .apply_over(cx, live! {draw_bg: {rotation: (0.0)}});
-        self.animator_cut(cx, id!(open.hide));
-        let modal = self.modal(id!(bot_options_modal));
+        self.animator_cut(cx, ids!(open.hide));
+        let modal = self.modal(ids!(bot_options_modal));
         modal.close(cx);
         self.redraw(cx);
     }
@@ -488,7 +488,7 @@ impl ModelSelector {
     }
 
     fn update_selected_model_info(&mut self, cx: &mut Cx, store: &Store) {
-        self.view(id!(choose)).set_visible(cx, false);
+        self.view(ids!(choose)).set_visible(cx, false);
 
         let associated_bot = store
             .chats
@@ -498,7 +498,7 @@ impl ModelSelector {
             let Some(bot) = store.chats.get_bot(&bot_id) else {
                 return;
             };
-            self.view(id!(icon_drop)).set_visible(cx, true);
+            self.view(ids!(icon_drop)).set_visible(cx, true);
 
             // Local model styling
             if store.chats.is_local_model(&bot_id) {
@@ -506,7 +506,7 @@ impl ModelSelector {
                 // on the fact that we use the file id as the name of the bot.
                 let file = store.downloads.get_file(&bot.name).cloned();
                 if let Some(file) = file {
-                    let selected_view = self.view(id!(selected_bot));
+                    let selected_view = self.view(ids!(selected_bot));
                     selected_view.set_visible(cx, true);
 
                     let file_size = format_model_size(file.size.trim()).unwrap_or("".into());
@@ -538,7 +538,7 @@ impl ModelSelector {
                 }
             } else {
                 // Any other model
-                let selected_view = self.view(id!(selected_bot));
+                let selected_view = self.view(ids!(selected_bot));
                 selected_view.set_visible(cx, true);
 
                 selected_view.apply_over(
@@ -567,7 +567,7 @@ impl ModelSelector {
             }
         }
 
-        self.view(id!(icon_drop)).apply_over(
+        self.view(ids!(icon_drop)).apply_over(
             cx,
             live! {
                 visible: true
@@ -577,14 +577,14 @@ impl ModelSelector {
 
     fn set_provider_icon(&mut self, cx: &mut Cx, provider_icon: Option<LiveDependency>) {
         if let Some(provider_icon) = provider_icon {
-            self.view(id!(selected_bot.provider_image_view))
+            self.view(ids!(selected_bot.provider_image_view))
                 .set_visible(cx, true);
 
             let _ = self
-                .image(id!(selected_bot.provider_image))
+                .image(ids!(selected_bot.provider_image))
                 .load_image_dep_by_path(cx, provider_icon.as_str());
         } else {
-            self.view(id!(selected_bot.provider_image_view))
+            self.view(ids!(selected_bot.provider_image_view))
                 .set_visible(cx, false);
         }
     }
@@ -604,7 +604,7 @@ impl ModelSelectorRef {
         if let Some(mut inner) = self.borrow_mut() {
             inner.chat_id = chat_id;
             inner
-                .model_selector_list(id!(list_container.list))
+                .model_selector_list(ids!(list_container.list))
                 .set_chat_id(chat_id);
         }
     }

--- a/src/chat/model_selector_item.rs
+++ b/src/chat/model_selector_item.rs
@@ -98,7 +98,7 @@ impl Widget for ModelSelectorItem {
 
 impl WidgetMatchEvent for ModelSelectorItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if let Some(fd) = self.view(id!(content)).finger_up(&actions) {
+        if let Some(fd) = self.view(ids!(content)).finger_up(&actions) {
             if fd.was_tap() {
                 cx.action(ModelSelectorAction::BotSelected(
                     self.chat_id,

--- a/src/chat/model_selector_list.rs
+++ b/src/chat/model_selector_list.rs
@@ -229,24 +229,26 @@ impl ModelSelectorList {
             let section_label = self.items.get_or_insert(cx, section_id, |cx| {
                 WidgetRef::new_from_ptr(cx, self.section_label_template)
             });
-            section_label.label(id!(label)).set_text(cx, &provider_name);
+            section_label
+                .label(ids!(label))
+                .set_text(cx, &provider_name);
 
             let provider_icon = store.get_provider_icon(&provider_name);
             if let Some(provider_icon) = provider_icon {
                 section_label
-                    .view(id!(provider_initial_view))
+                    .view(ids!(provider_initial_view))
                     .set_visible(cx, false);
-                section_label.view(id!(image_view)).set_visible(cx, true);
+                section_label.view(ids!(image_view)).set_visible(cx, true);
                 let _ = section_label
-                    .image(id!(image))
+                    .image(ids!(image))
                     .load_image_dep_by_path(cx, provider_icon.as_str());
             } else {
-                section_label.view(id!(image_view)).set_visible(cx, false);
+                section_label.view(ids!(image_view)).set_visible(cx, false);
                 section_label
-                    .view(id!(provider_initial_view))
+                    .view(ids!(provider_initial_view))
                     .set_visible(cx, true);
                 section_label
-                    .label(id!(provider_initial_label))
+                    .label(ids!(provider_initial_label))
                     .set_text(cx, &provider_name.chars().next().unwrap().to_string());
             }
             let _ = section_label.draw_all(cx, &mut Scope::empty());
@@ -320,7 +322,7 @@ impl ModelSelectorList {
                     .set_chat_id(self.chat_id);
 
                 let _ = item_widget.draw_all(cx, &mut Scope::empty());
-                total_height += item_widget.view(id!(content)).area().rect(cx).size.y;
+                total_height += item_widget.view(ids!(content)).area().rect(cx).size.y;
             }
         }
 

--- a/src/chat/model_selector_loading.rs
+++ b/src/chat/model_selector_loading.rs
@@ -157,11 +157,11 @@ impl ModelSelectorLoading {
     pub fn update_animation(&mut self, cx: &mut Cx) {
         self.visible = true;
 
-        if self.animator_in_state(cx, id!(line.restart)) {
-            self.animator_play(cx, id!(line.run));
+        if self.animator_in_state(cx, ids!(line.restart)) {
+            self.animator_play(cx, ids!(line.run));
             self.timer = cx.start_timeout(1.5);
         } else {
-            self.animator_play(cx, id!(line.restart));
+            self.animator_play(cx, ids!(line.restart));
         }
     }
 
@@ -179,7 +179,7 @@ impl ModelSelectorLoading {
         // Calculate the width - 5.0 is the multiplier (500px / 100%)
         let progress_bar_width = progress_percentage * 5.0 * 100.0;
 
-        self.view(id!(progress_container.progress_bar)).apply_over(
+        self.view(ids!(progress_container.progress_bar)).apply_over(
             cx,
             live! {
                 width: (progress_bar_width)
@@ -190,7 +190,7 @@ impl ModelSelectorLoading {
     fn complete_progress_bar(&mut self, cx: &mut Cx) {
         // Always animate to full width before disappearing
         // Set width to full 500px to ensure it completes
-        self.view(id!(progress_container.progress_bar)).apply_over(
+        self.view(ids!(progress_container.progress_bar)).apply_over(
             cx,
             live! {
                 width: 500.0
@@ -202,10 +202,10 @@ impl ModelSelectorLoading {
     }
 
     fn hide_progress_components(&mut self, cx: &mut Cx) {
-        self.view(id!(progress_container.background))
+        self.view(ids!(progress_container.background))
             .set_visible(cx, false);
 
-        self.view(id!(progress_container.progress_bar)).apply_over(
+        self.view(ids!(progress_container.progress_bar)).apply_over(
             cx,
             live! {
                 visible: false,
@@ -217,9 +217,9 @@ impl ModelSelectorLoading {
     }
 
     fn show_progress_components(&mut self, cx: &mut Cx) {
-        self.view(id!(progress_container.background))
+        self.view(ids!(progress_container.background))
             .set_visible(cx, true);
-        self.view(id!(progress_container.progress_bar))
+        self.view(ids!(progress_container.progress_bar))
             .set_visible(cx, true);
     }
 }

--- a/src/chat/prompt_input.rs
+++ b/src/chat/prompt_input.rs
@@ -226,10 +226,10 @@ impl Widget for PromptInput {
 
 impl WidgetMatchEvent for PromptInput {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        let mut prompt = self.command_text_input(id!(prompt));
+        let mut prompt = self.command_text_input(ids!(prompt));
 
         if let Some(item) = prompt.item_selected(actions) {
-            let entity_button = item.entity_button(id!(button));
+            let entity_button = item.entity_button(ids!(button));
             let bot_id = entity_button.get_bot_id();
             if let Some(bot_id) = bot_id {
                 self.on_bot_selected(cx, scope, &bot_id);
@@ -285,7 +285,7 @@ impl WidgetMatchEvent for PromptInput {
                 // Add models for this provider
                 for model in models {
                     let option = WidgetRef::new_from_ptr(cx, self.entity_template);
-                    let mut entity_button = option.entity_button(id!(button));
+                    let mut entity_button = option.entity_button(ids!(button));
                     entity_button.set_bot_id(cx, &model.id);
                     entity_button.set_description_visible(cx, true);
                     prompt.add_item(option);
@@ -305,7 +305,7 @@ impl WidgetMatchEvent for PromptInput {
                 }
 
                 let option = WidgetRef::new_from_ptr(cx, self.entity_template);
-                let mut entity_button = option.entity_button(id!(button));
+                let mut entity_button = option.entity_button(ids!(button));
                 entity_button.set_bot_id(cx, &agent.id);
                 entity_button.set_description_visible(cx, true);
                 prompt.add_item(option);
@@ -327,7 +327,7 @@ impl WidgetMatchEvent for PromptInput {
                 }
 
                 let option = WidgetRef::new_from_ptr(cx, self.entity_template);
-                let mut entity_button = option.entity_button(id!(button));
+                let mut entity_button = option.entity_button(ids!(button));
                 let bot_id = store
                     .chats
                     .available_bots
@@ -346,7 +346,7 @@ impl WidgetMatchEvent for PromptInput {
             self.on_deselected(cx);
         }
 
-        if self.button(id!(deselect_button)).clicked(actions) {
+        if self.button(ids!(deselect_button)).clicked(actions) {
             self.on_deselected(cx);
         }
 
@@ -360,7 +360,7 @@ impl WidgetMatchEvent for PromptInput {
 
             match action.cast() {
                 CaptureAction::Capture { event } => {
-                    self.command_text_input(id!(prompt))
+                    self.command_text_input(ids!(prompt))
                         .set_text(cx, event.contents());
                 }
                 _ => {}
@@ -379,26 +379,26 @@ impl PromptInput {
     fn on_bot_selected(&mut self, cx: &mut Cx, scope: &mut Scope, bot_id: &BotId) {
         let store = scope.data.get::<Store>().unwrap();
 
-        let mut agent_avatar = self.chat_agent_avatar(id!(agent_avatar));
-        let label = self.label(id!(selected_label));
+        let mut agent_avatar = self.chat_agent_avatar(ids!(agent_avatar));
+        let label = self.label(ids!(selected_label));
 
         let bot = store.chats.get_bot_or_placeholder(bot_id);
         label.set_text(cx, &bot.name);
         agent_avatar.set_visible(false);
 
         self.selected_bot = Some(bot_id.clone());
-        self.view(id!(selected_bubble)).set_visible(cx, true);
+        self.view(ids!(selected_bubble)).set_visible(cx, true);
     }
 
     fn on_deselected(&mut self, cx: &mut Cx) {
         self.selected_bot = None;
-        self.view(id!(selected_bubble)).set_visible(cx, false);
+        self.view(ids!(selected_bubble)).set_visible(cx, false);
     }
 }
 
 impl LiveHook for PromptInput {
     fn after_new_from_doc(&mut self, cx: &mut Cx) {
-        let prompt = self.command_text_input(id!(prompt));
+        let prompt = self.command_text_input(ids!(prompt));
         prompt.apply_over(cx, live! { trigger: "@" });
         prompt.text_input_ref().apply_over(
             cx,

--- a/src/data/store.rs
+++ b/src/data/store.rs
@@ -113,7 +113,7 @@ impl Store {
 
             app_runner().defer(move |app, cx, _| {
                 app.store = Some(store);
-                app.ui.view(id!(body)).set_visible(cx, true);
+                app.ui.view(ids!(body)).set_visible(cx, true);
                 cx.redraw_all(); // app.ui.redraw(cx) doesn't work as expected on web.
             });
         })

--- a/src/landing/download_item.rs
+++ b/src/landing/download_item.rs
@@ -226,17 +226,17 @@ impl Widget for DownloadItem {
         let download = scope.data.get::<PendingDownload>().unwrap();
         self.file_id = Some(download.file.id.clone());
 
-        self.label(id!(filename))
+        self.label(ids!(filename))
             .set_text(cx, download.file.name.as_str());
 
-        self.label(id!(architecture_tag.caption))
+        self.label(ids!(architecture_tag.caption))
             .set_text(cx, download.model.architecture.as_str());
 
-        self.label(id!(params_size_tag.caption))
+        self.label(ids!(params_size_tag.caption))
             .set_text(cx, &&download.model.requires.as_str());
 
         let progress_bar_width = download.progress * 6.0; // 6.0 = 600px / 100%
-        let label = self.label(id!(progress));
+        let label = self.label(ids!(progress));
         match download.status {
             PendingDownloadsStatus::Initializing => {
                 let downloading_color = vec3(0.035, 0.572, 0.314); //#099250
@@ -248,7 +248,7 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(progress_bar)).apply_over(
+                self.view(ids!(progress_bar)).apply_over(
                     cx,
                     live! {
                         width: (progress_bar_width)
@@ -256,10 +256,10 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(cx, false);
-                self.button(id!(play_button)).set_visible(cx, false);
-                self.button(id!(retry_button)).set_visible(cx, false);
-                self.button(id!(cancel_button)).set_visible(cx, false);
+                self.button(ids!(pause_button)).set_visible(cx, false);
+                self.button(ids!(play_button)).set_visible(cx, false);
+                self.button(ids!(retry_button)).set_visible(cx, false);
+                self.button(ids!(cancel_button)).set_visible(cx, false);
             }
             PendingDownloadsStatus::Downloading => {
                 let downloading_color = vec3(0.035, 0.572, 0.314); //#099250
@@ -271,7 +271,7 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(progress_bar)).apply_over(
+                self.view(ids!(progress_bar)).apply_over(
                     cx,
                     live! {
                         width: (progress_bar_width)
@@ -279,10 +279,10 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(cx, true);
-                self.button(id!(play_button)).set_visible(cx, false);
-                self.button(id!(retry_button)).set_visible(cx, false);
-                self.button(id!(cancel_button)).set_visible(cx, true);
+                self.button(ids!(pause_button)).set_visible(cx, true);
+                self.button(ids!(play_button)).set_visible(cx, false);
+                self.button(ids!(retry_button)).set_visible(cx, false);
+                self.button(ids!(cancel_button)).set_visible(cx, true);
             }
             PendingDownloadsStatus::Paused => {
                 let paused_color = vec3(0.4, 0.44, 0.52); //#667085
@@ -294,7 +294,7 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(progress_bar)).apply_over(
+                self.view(ids!(progress_bar)).apply_over(
                     cx,
                     live! {
                         width: (progress_bar_width)
@@ -302,10 +302,10 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(cx, false);
-                self.button(id!(play_button)).set_visible(cx, true);
-                self.button(id!(retry_button)).set_visible(cx, false);
-                self.button(id!(cancel_button)).set_visible(cx, true);
+                self.button(ids!(pause_button)).set_visible(cx, false);
+                self.button(ids!(play_button)).set_visible(cx, true);
+                self.button(ids!(retry_button)).set_visible(cx, false);
+                self.button(ids!(cancel_button)).set_visible(cx, true);
             }
             PendingDownloadsStatus::Error => {
                 let failed_color = vec3(0.7, 0.11, 0.09); // #B42318
@@ -317,7 +317,7 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.view(id!(progress_bar)).apply_over(
+                self.view(ids!(progress_bar)).apply_over(
                     cx,
                     live! {
                         width: (progress_bar_width)
@@ -325,10 +325,10 @@ impl Widget for DownloadItem {
                     },
                 );
 
-                self.button(id!(pause_button)).set_visible(cx, false);
-                self.button(id!(play_button)).set_visible(cx, false);
-                self.button(id!(retry_button)).set_visible(cx, true);
-                self.button(id!(cancel_button)).set_visible(cx, true);
+                self.button(ids!(pause_button)).set_visible(cx, false);
+                self.button(ids!(play_button)).set_visible(cx, false);
+                self.button(ids!(retry_button)).set_visible(cx, true);
+                self.button(ids!(cancel_button)).set_visible(cx, true);
             }
         }
 
@@ -336,7 +336,7 @@ impl Widget for DownloadItem {
         let downloaded_size = format_model_downloaded_size(&download.file.size, download.progress)
             .unwrap_or("-".to_string());
 
-        self.label(id!(downloaded_size))
+        self.label(ids!(downloaded_size))
             .set_text(cx, &format!("{} / {}", downloaded_size, total_size));
 
         self.view.draw_walk(cx, scope, walk)
@@ -353,19 +353,19 @@ impl WidgetMatchEvent for DownloadItem {
             }
         }
 
-        for button_id in [id!(play_button), id!(retry_button)] {
+        for button_id in [ids!(play_button), ids!(retry_button)] {
             if self.button(button_id).clicked(&actions) {
                 let Some(file_id) = &self.file_id else { return };
                 cx.action(DownloadAction::Play(file_id.clone()));
             }
         }
 
-        if self.button(id!(pause_button)).clicked(&actions) {
+        if self.button(ids!(pause_button)).clicked(&actions) {
             let Some(file_id) = &self.file_id else { return };
             cx.action(DownloadAction::Pause(file_id.clone()));
         }
 
-        if self.button(id!(cancel_button)).clicked(&actions) {
+        if self.button(ids!(cancel_button)).clicked(&actions) {
             let Some(file_id) = &self.file_id else { return };
             cx.action(DownloadAction::Cancel(file_id.clone()));
         }

--- a/src/landing/downloads.rs
+++ b/src/landing/downloads.rs
@@ -165,14 +165,14 @@ impl Widget for Downloads {
                 )
             })
             .count();
-        self.label(id!(downloading_count))
+        self.label(ids!(downloading_count))
             .set_text(cx, &format!("{} downloading", download_count));
 
         let paused_count = pending_downloads
             .iter()
             .filter(|d| matches!(d.status, PendingDownloadsStatus::Paused))
             .count();
-        self.label(id!(paused_count))
+        self.label(ids!(paused_count))
             .set_text(cx, &format!("{} paused", paused_count));
 
         let failed_count = pending_downloads
@@ -181,10 +181,10 @@ impl Widget for Downloads {
             .count();
 
         if failed_count > 0 {
-            self.label(id!(failed_count))
+            self.label(ids!(failed_count))
                 .set_text(cx, &format!("{} failed", failed_count));
         } else {
-            self.label(id!(failed_count)).set_text(cx, "");
+            self.label(ids!(failed_count)).set_text(cx, "");
         }
 
         while let Some(view_item) = self.view.draw_walk(cx, &mut Scope::empty(), walk).step() {
@@ -207,7 +207,7 @@ impl Widget for Downloads {
 
 impl WidgetMatchEvent for Downloads {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(collapse)).clicked(&actions) {
+        if self.button(ids!(collapse)).clicked(&actions) {
             self.toggle_collapse(cx);
         }
     }
@@ -215,18 +215,18 @@ impl WidgetMatchEvent for Downloads {
 
 impl Downloads {
     fn toggle_collapse(&mut self, cx: &mut Cx) {
-        if self.animator.animator_in_state(cx, id!(content.collapse)) {
-            self.animator_play(cx, id!(content.expand));
+        if self.animator.animator_in_state(cx, ids!(content.collapse)) {
+            self.animator_play(cx, ids!(content.expand));
             self.set_collapse_button_open(cx, true)
         } else {
-            self.animator_play(cx, id!(content.collapse));
+            self.animator_play(cx, ids!(content.collapse));
             self.set_collapse_button_open(cx, false)
         }
     }
 
     fn set_collapse_button_open(&mut self, cx: &mut Cx, is_open: bool) {
         let rotation_angle = if is_open { 0.0 } else { 180.0 };
-        self.button(id!(collapse)).apply_over(
+        self.button(ids!(collapse)).apply_over(
             cx,
             live! {
                 draw_icon: { rotation_angle: (rotation_angle) }

--- a/src/landing/landing_screen.rs
+++ b/src/landing/landing_screen.rs
@@ -84,18 +84,18 @@ impl Widget for LandingScreen {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let search = &scope.data.get::<Store>().unwrap().search;
         if search.is_pending() || search.was_error() {
-            self.view(id!(heading_with_filters)).set_visible(cx, false);
+            self.view(ids!(heading_with_filters)).set_visible(cx, false);
         } else if let Some(keyword) = search.keyword.clone() {
-            self.view(id!(heading_with_filters)).set_visible(cx, true);
+            self.view(ids!(heading_with_filters)).set_visible(cx, true);
 
             let models = &search.models;
             let models_count = models.len();
-            self.label(id!(heading_with_filters.results))
+            self.label(ids!(heading_with_filters.results))
                 .set_text(cx, &format!("{} Results", models_count));
-            self.label(id!(heading_with_filters.keyword))
+            self.label(ids!(heading_with_filters.keyword))
                 .set_text(cx, &format!(" for \"{}\"", keyword));
         } else {
-            self.view(id!(heading_with_filters)).set_visible(cx, false);
+            self.view(ids!(heading_with_filters)).set_visible(cx, false);
         }
 
         self.view.draw_walk(cx, scope, walk)
@@ -113,7 +113,7 @@ impl WidgetMatchEvent for LandingScreen {
                 ModelListAction::ScrolledAtTop => {
                     if self.search_bar_state == SearchBarState::CollapsedWithoutFilters {
                         self.search_bar_state = SearchBarState::ExpandedWithoutFilters;
-                        self.search_bar(id!(search_bar)).expand(cx);
+                        self.search_bar(ids!(search_bar)).expand(cx);
                         self.redraw(cx);
                     }
                 }
@@ -135,7 +135,7 @@ impl WidgetMatchEvent for LandingScreen {
 
                     if collapse {
                         let search = &scope.data.get::<Store>().unwrap().search;
-                        self.search_bar(id!(search_bar))
+                        self.search_bar(ids!(search_bar))
                             .collapse(cx, search.sorted_by);
                         self.redraw(cx);
                     }
@@ -156,7 +156,7 @@ impl WidgetMatchEvent for LandingScreen {
                 StoreAction::ResetSearch => match self.search_bar_state {
                     SearchBarState::ExpandedWithFilters | SearchBarState::CollapsedWithFilters => {
                         self.search_bar_state = SearchBarState::ExpandedWithoutFilters;
-                        self.search_bar(id!(search_bar)).expand(cx);
+                        self.search_bar(ids!(search_bar)).expand(cx);
                     }
                     _ => {}
                 },

--- a/src/landing/model_card.rs
+++ b/src/landing/model_card.rs
@@ -350,26 +350,26 @@ impl Widget for ModelCard {
         self.model_id = model.model_id.clone();
 
         let name = &model.name;
-        self.label(id!(model_name)).set_text(cx, name);
+        self.label(ids!(model_name)).set_text(cx, name);
 
         let download_count = &model.download_count;
-        self.label(id!(model_download_count.attr_value))
+        self.label(ids!(model_download_count.attr_value))
             .set_text(cx, &format!("{}", download_count));
 
         let like_count = &model.like_count;
-        self.label(id!(model_like_count.attr_value))
+        self.label(ids!(model_like_count.attr_value))
             .set_text(cx, &format!("{}", like_count));
 
         let size = &model.size;
-        self.label(id!(model_size_tag.attr_value))
+        self.label(ids!(model_size_tag.attr_value))
             .set_text(cx, size);
 
         let requires = &model.requires;
-        self.label(id!(model_requires_tag.attr_value))
+        self.label(ids!(model_requires_tag.attr_value))
             .set_text(cx, requires);
 
         let architecture = &model.architecture;
-        self.label(id!(model_architecture_tag.attr_value))
+        self.label(ids!(model_architecture_tag.attr_value))
             .set_text(cx, architecture);
 
         let summary = &model.summary;
@@ -383,27 +383,28 @@ impl Widget for ModelCard {
         } else {
             summary.to_string()
         };
-        self.label(id!(model_summary))
+        self.label(ids!(model_summary))
             .set_text(cx, &trimmed_summary);
 
         let author_name = &model.author.name;
         let author_url = &model.author.url;
-        let mut author_external_link = self.external_link(id!(author_link));
+        let mut author_external_link = self.external_link(ids!(author_link));
         author_external_link
-            .link_label(id!(link))
+            .link_label(ids!(link))
             .set_text(cx, author_name);
         author_external_link.set_url(author_url);
 
         let model_hugging_face_url = hugging_face_model_url(&model.model_id);
-        let mut model_hugging_face_external_link = self.external_link(id!(model_hugging_face_link));
+        let mut model_hugging_face_external_link =
+            self.external_link(ids!(model_hugging_face_link));
         model_hugging_face_external_link.set_url(&model_hugging_face_url);
 
         let author_description = &model.author.description;
-        self.label(id!(author_description))
+        self.label(ids!(author_description))
             .set_text(cx, author_description);
 
         let released_at_str = formatted_model_release_date(&model);
-        self.label(id!(model_released_at_tag.attr_value))
+        self.label(ids!(model_released_at_tag.attr_value))
             .set_text(cx, &released_at_str);
 
         self.view.draw_walk(cx, scope, walk)
@@ -412,14 +413,14 @@ impl Widget for ModelCard {
 
 impl WidgetMatchEvent for ModelCard {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.link_label(id!(view_all_button.link)).clicked(actions) {
-            self.modal(id!(modal)).open(cx);
+        if self.link_label(ids!(view_all_button.link)).clicked(actions) {
+            self.modal(ids!(modal)).open(cx);
             self.redraw(cx);
         }
 
         for action in actions {
             if let ModelCardViewAllModalAction::CloseButtonClicked = action.cast() {
-                self.modal(id!(modal)).close(cx);
+                self.modal(ids!(modal)).close(cx);
                 self.redraw(cx);
             }
         }
@@ -448,10 +449,10 @@ impl Widget for ModelCardViewAllModal {
         let model = &scope.data.get::<ModelWithDownloadInfo>().unwrap();
 
         let name = &model.name;
-        self.label(id!(view_all_model_name)).set_text(cx, name);
+        self.label(ids!(view_all_model_name)).set_text(cx, name);
 
         let summary = &model.summary;
-        self.label(id!(view_all_model_summary))
+        self.label(ids!(view_all_model_summary))
             .set_text(cx, summary);
 
         self.view
@@ -461,7 +462,7 @@ impl Widget for ModelCardViewAllModal {
 
 impl WidgetMatchEvent for ModelCardViewAllModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(ModelCardViewAllModalAction::CloseButtonClicked);
         }
     }

--- a/src/landing/model_files.rs
+++ b/src/landing/model_files.rs
@@ -195,7 +195,7 @@ impl Widget for ModelFiles {
         if self.animator_handle_event(cx, event).must_redraw() {
             if let Some(total_height) = self.actual_height {
                 let height = self.show_all_animation_progress * total_height;
-                self.view(id!(remaining_files_wrapper))
+                self.view(ids!(remaining_files_wrapper))
                     .apply_over(cx, live! {height: (height)});
                 self.redraw(cx);
             }
@@ -207,17 +207,17 @@ impl Widget for ModelFiles {
         let files_count = model.files.len();
         let featured_count = model.files.iter().filter(|f| f.file.featured).count();
 
-        let show_all_button = self.radio_button(id!(tab_buttons.show_all_button));
+        let show_all_button = self.radio_button(ids!(tab_buttons.show_all_button));
         show_all_button.set_text(cx, &format!("All Files ({})", files_count));
 
-        let show_all_button = self.radio_button(id!(tab_buttons.only_recommended_button));
+        let show_all_button = self.radio_button(ids!(tab_buttons.only_recommended_button));
         show_all_button.set_text(cx, &format!("Only Recommended Files ({})", featured_count));
 
         let _ = self.view.draw_walk(cx, scope, walk);
 
         // Let's remember the actual rendered height of the remaining_files element.
         if self.actual_height.is_none() {
-            self.actual_height = Some(self.model_files_list(id!(remaining_files)).get_height(cx))
+            self.actual_height = Some(self.model_files_list(ids!(remaining_files)).get_height(cx))
         }
 
         DrawStep::done()
@@ -226,19 +226,21 @@ impl Widget for ModelFiles {
 
 impl WidgetMatchEvent for ModelFiles {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        let actions_tab_buttons = self.widget(id!(model_files_actions)).radio_button_set(ids!(
-            tab_buttons.show_all_button,
-            tab_buttons.only_recommended_button,
-        ));
+        let actions_tab_buttons =
+            self.widget(ids!(model_files_actions))
+                .radio_button_set(ids_array!(
+                    tab_buttons.show_all_button,
+                    tab_buttons.only_recommended_button,
+                ));
 
         if let Some(index) = actions_tab_buttons.selected(cx, actions) {
             match index {
                 0 => {
-                    self.animator_play(cx, id!(show_all.show));
+                    self.animator_play(cx, ids!(show_all.show));
                     self.redraw(cx);
                 }
                 1 => {
-                    self.animator_play(cx, id!(show_all.hide));
+                    self.animator_play(cx, ids!(show_all.hide));
                     self.redraw(cx);
                 }
                 _ => {}
@@ -250,7 +252,7 @@ impl WidgetMatchEvent for ModelFiles {
                 StoreAction::Search(_) | StoreAction::ResetSearch | StoreAction::Sort(_) => {
                     self.expand_without_animation(cx);
                     self.actual_height = None;
-                    self.radio_button(id!(show_all_button)).select(cx, scope);
+                    self.radio_button(ids!(show_all_button)).select(cx, scope);
                     self.redraw(cx);
                 }
                 _ => {}
@@ -261,7 +263,7 @@ impl WidgetMatchEvent for ModelFiles {
 
 impl ModelFiles {
     fn expand_without_animation(&mut self, cx: &mut Cx) {
-        self.view(id!(remaining_files_wrapper))
+        self.view(ids!(remaining_files_wrapper))
             .apply_over(cx, live! {height: Fit});
         self.show_all_animation_progress = 0.0;
         self.redraw(cx);

--- a/src/landing/model_files_item.rs
+++ b/src/landing/model_files_item.rs
@@ -342,11 +342,11 @@ impl WidgetMatchEvent for ModelFilesItem {
             return;
         };
 
-        if self.button(id!(download_button)).clicked(&actions) {
+        if self.button(ids!(download_button)).clicked(&actions) {
             cx.action(ModelFileItemAction::Download(file_id.clone()));
         }
 
-        if self.button(id!(start_chat_button)).clicked(&actions) {
+        if self.button(ids!(start_chat_button)).clicked(&actions) {
             let store = scope.data.get_mut::<Store>().unwrap();
             let bot_id = store.chats.get_bot_id_by_file_id(&file_id);
             if let Some(bot_id) = bot_id {
@@ -354,18 +354,18 @@ impl WidgetMatchEvent for ModelFilesItem {
             }
         }
 
-        if [id!(resume_download_button), id!(retry_download_button)]
+        if [ids!(resume_download_button), ids!(retry_download_button)]
             .iter()
             .any(|id| self.button(*id).clicked(&actions))
         {
             cx.action(DownloadAction::Play(file_id.clone()));
         }
 
-        if self.button(id!(pause_download_button)).clicked(&actions) {
+        if self.button(ids!(pause_download_button)).clicked(&actions) {
             cx.action(DownloadAction::Pause(file_id.clone()));
         }
 
-        if self.button(id!(cancel_download_button)).clicked(&actions) {
+        if self.button(ids!(cancel_download_button)).clicked(&actions) {
             cx.action(DownloadAction::Cancel(file_id.clone()));
         }
     }
@@ -380,7 +380,7 @@ impl ModelFilesItemRef {
         item_widget.file_id = Some(file.id.clone());
 
         item_widget
-            .model_files_tags(id!(tags))
+            .model_files_tags(ids!(tags))
             .set_tags(cx, &file.tags);
     }
 }

--- a/src/landing/model_list.rs
+++ b/src/landing/model_list.rs
@@ -205,7 +205,7 @@ impl Widget for ModelList {
                                     },
                                 );
 
-                                [id!(first), id!(second), id!(third)]
+                                [ids!(first), ids!(second), ids!(third)]
                                     .iter()
                                     .enumerate()
                                     .for_each(|(i, id)| {
@@ -217,7 +217,7 @@ impl Widget for ModelList {
                                                     show_bg: true,
                                                 },
                                             );
-                                            let mut button = cell.entity_button(id!(button));
+                                            let mut button = cell.entity_button(ids!(button));
                                             button.set_bot_id(cx, &agent.id);
                                             button.set_description_visible(cx, true);
                                         }
@@ -255,12 +255,12 @@ const SCROLLING_AT_TOP_THRESHOLD: f64 = -30.0;
 
 impl WidgetMatchEvent for ModelList {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        let portal_list = self.portal_list(id!(list));
+        let portal_list = self.portal_list(ids!(list));
 
         let clicked_entity_button = portal_list
             .items_with_actions(actions)
             .iter()
-            .map(|(_, item)| item.entity_button(id!(button)))
+            .map(|(_, item)| item.entity_button(ids!(button)))
             .find(|button| button.clicked(actions));
 
         if let Some(entity_button) = clicked_entity_button {
@@ -277,9 +277,9 @@ impl WidgetMatchEvent for ModelList {
 
             match action.cast() {
                 StoreAction::Search(_) | StoreAction::ResetSearch => {
-                    self.view(id!(search_error)).set_visible(cx, false);
-                    self.view(id!(loading)).set_visible(cx, true);
-                    self.search_loading(id!(search_loading)).animate(cx);
+                    self.view(ids!(search_error)).set_visible(cx, false);
+                    self.view(ids!(loading)).set_visible(cx, true);
+                    self.search_loading(ids!(search_loading)).animate(cx);
                     portal_list.set_first_id_and_scroll(0, 0.0);
 
                     self.redraw(cx);
@@ -304,14 +304,14 @@ impl ModelList {
     fn update_loading_and_error_message(&mut self, cx: &mut Cx, scope: &mut Scope) {
         let store = scope.data.get::<Store>().unwrap();
         let is_loading = store.search.is_pending();
-        self.view(id!(loading)).set_visible(cx, is_loading);
+        self.view(ids!(loading)).set_visible(cx, is_loading);
         if is_loading {
-            self.search_loading(id!(search_loading)).animate(cx);
+            self.search_loading(ids!(search_loading)).animate(cx);
         } else {
-            self.search_loading(id!(search_loading)).stop_animation();
+            self.search_loading(ids!(search_loading)).stop_animation();
         }
 
         let is_errored = store.search.was_error();
-        self.view(id!(search_error)).set_visible(cx, is_errored);
+        self.view(ids!(search_error)).set_visible(cx, is_errored);
     }
 }

--- a/src/landing/search_bar.rs
+++ b/src/landing/search_bar.rs
@@ -165,7 +165,7 @@ impl Widget for SearchBar {
         if self.search_timer.is_event(event).is_some() {
             self.search_timer = Timer::default();
 
-            let input = self.text_input(id!(input));
+            let input = self.text_input(ids!(input));
             let keywords = input.text();
             const MIN_SEARCH_LENGTH: usize = 2;
 
@@ -184,8 +184,8 @@ impl Widget for SearchBar {
 
 impl WidgetMatchEvent for SearchBar {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        let input = self.text_input(id!(input));
-        let clear_text_button = self.button(id!(clear_text_button));
+        let input = self.text_input(ids!(input));
+        let clear_text_button = self.button(ids!(clear_text_button));
 
         if let Some((keywords, _)) = input.returned(actions) {
             if keywords.len() > 0 {
@@ -201,7 +201,7 @@ impl WidgetMatchEvent for SearchBar {
             self.search_timer = cx.start_timeout(self.search_debounce_time);
         }
 
-        if self.button(id!(clear_text_button)).clicked(actions) {
+        if self.button(ids!(clear_text_button)).clicked(actions) {
             input.set_text(cx, "");
             clear_text_button.set_visible(cx, false);
             input.set_key_focus(cx);
@@ -235,9 +235,9 @@ impl SearchBarRef {
         );
 
         inner
-            .sorting(id!(search_sorting))
+            .sorting(ids!(search_sorting))
             .set_selected_item(cx, selected_sort);
-        inner.animator_play(cx, id!(search_bar.collapsed));
+        inner.animator_play(cx, ids!(search_bar.collapsed));
     }
 
     pub fn expand(&self, cx: &mut Cx) {
@@ -262,6 +262,6 @@ impl SearchBarRef {
             },
         );
 
-        inner.animator_play(cx, id!(search_bar.expanded));
+        inner.animator_play(cx, ids!(search_bar.expanded));
     }
 }

--- a/src/landing/search_loading.rs
+++ b/src/landing/search_loading.rs
@@ -133,16 +133,16 @@ impl SearchLoading {
 
         match self.current_animated_circle {
             0 => {
-                self.animator_play(cx, id!(circle1.run));
-                self.animator_play(cx, id!(circle3.start));
+                self.animator_play(cx, ids!(circle1.run));
+                self.animator_play(cx, ids!(circle3.start));
             }
             1 => {
-                self.animator_play(cx, id!(circle1.start));
-                self.animator_play(cx, id!(circle2.run));
+                self.animator_play(cx, ids!(circle1.start));
+                self.animator_play(cx, ids!(circle2.run));
             }
             2 => {
-                self.animator_play(cx, id!(circle2.start));
-                self.animator_play(cx, id!(circle3.run));
+                self.animator_play(cx, ids!(circle2.start));
+                self.animator_play(cx, ids!(circle3.run));
             }
             _ => unreachable!(),
         };

--- a/src/landing/sorting.rs
+++ b/src/landing/sorting.rs
@@ -161,7 +161,7 @@ impl Widget for Sorting {
 
 impl WidgetMatchEvent for Sorting {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if let Some(item_selected) = self.drop_down(id!(options)).selected(&actions) {
+        if let Some(item_selected) = self.drop_down(ids!(options)).selected(&actions) {
             // TODO Check if we can use liveids instead of item index
             let criteria = match item_selected {
                 0 => SortCriteria::MostDownloads,
@@ -200,7 +200,7 @@ impl SortingRef {
             SortCriteria::LeastLikes => 3,
         };
         inner
-            .drop_down(id!(options))
+            .drop_down(ids!(options))
             .set_selected_item(cx, criteria_id);
     }
 }

--- a/src/mcp/mcp_screen.rs
+++ b/src/mcp/mcp_screen.rs
@@ -62,7 +62,7 @@ impl Widget for McpScreen {
 
 impl WidgetMatchEvent for McpScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        let stack_navigation = self.stack_navigation(id!(navigation));
+        let stack_navigation = self.stack_navigation(ids!(navigation));
         stack_navigation.handle_stack_view_actions(cx, actions);
     }
 }

--- a/src/mcp/mcp_servers.rs
+++ b/src/mcp/mcp_servers.rs
@@ -276,7 +276,7 @@ impl Widget for McpServers {
         self.view.handle_event(cx, event, scope);
         self.widget_match_event(cx, event, scope);
 
-        let editor = self.widget(id!(mcp_code_view));
+        let editor = self.widget(ids!(mcp_code_view));
 
         if !self.initialized || editor.text().is_empty() {
             self.initialized = true;
@@ -307,22 +307,22 @@ impl McpServers {
             .to_json()
             .unwrap_or_else(|_| "{}".to_string());
 
-        self.widget(id!(mcp_code_view)).set_text(cx, &display_json);
+        self.widget(ids!(mcp_code_view)).set_text(cx, &display_json);
 
         // Sync the toggle UI to match the config's enabled state
-        self.check_box(id!(servers_enabled_switch))
+        self.check_box(ids!(servers_enabled_switch))
             .set_active(cx, self.mcp_servers_config.enabled);
 
         // Sync the dangerous mode toggle UI to match the config
-        self.check_box(id!(dangerous_mode_switch))
+        self.check_box(ids!(dangerous_mode_switch))
             .set_active(cx, self.mcp_servers_config.dangerous_mode_enabled);
     }
 }
 
 impl WidgetMatchEvent for McpServers {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.view(id!(save_button)).finger_up(actions).is_some() {
-            let json_text = self.widget(id!(mcp_code_view)).text();
+        if self.view(ids!(save_button)).finger_up(actions).is_some() {
+            let json_text = self.widget(ids!(mcp_code_view)).text();
 
             match McpServersConfig::from_json(&json_text) {
                 Ok(config) => {
@@ -338,17 +338,18 @@ impl WidgetMatchEvent for McpServers {
                             // Update our local config and UI
                             self.set_mcp_servers_config(cx, config);
 
-                            self.label(id!(save_status)).set_text(cx, "");
+                            self.label(ids!(save_status)).set_text(cx, "");
                             self.redraw(cx);
                         }
                         Err(e) => {
-                            self.label(id!(save_status)).set_text(cx, &format!("{}", e));
+                            self.label(ids!(save_status))
+                                .set_text(cx, &format!("{}", e));
                             self.redraw(cx);
                         }
                     }
                 }
                 Err(e) => {
-                    self.label(id!(save_status))
+                    self.label(ids!(save_status))
                         .set_text(cx, &format!("Invalid JSON: {}", e));
                     self.redraw(cx);
                 }
@@ -356,7 +357,7 @@ impl WidgetMatchEvent for McpServers {
         }
 
         // Handle MCP servers enabled switch
-        let servers_enabled_switch = self.check_box(id!(servers_enabled_switch));
+        let servers_enabled_switch = self.check_box(ids!(servers_enabled_switch));
         if let Some(enabled) = servers_enabled_switch.changed(actions) {
             // Update the local config
             self.mcp_servers_config.enabled = enabled;
@@ -366,7 +367,7 @@ impl WidgetMatchEvent for McpServers {
                 .mcp_servers_config
                 .to_json()
                 .unwrap_or_else(|_| "{}".to_string());
-            self.widget(id!(mcp_code_view)).set_text(cx, &display_json);
+            self.widget(ids!(mcp_code_view)).set_text(cx, &display_json);
 
             // Sync to Store
             let store = scope.data.get_mut::<Store>().unwrap();
@@ -375,7 +376,7 @@ impl WidgetMatchEvent for McpServers {
         }
 
         // Handle dangerous mode switch
-        let dangerous_mode_switch = self.check_box(id!(dangerous_mode_switch));
+        let dangerous_mode_switch = self.check_box(ids!(dangerous_mode_switch));
         if let Some(enabled) = dangerous_mode_switch.changed(actions) {
             // Update the local config
             self.mcp_servers_config.dangerous_mode_enabled = enabled;
@@ -385,7 +386,7 @@ impl WidgetMatchEvent for McpServers {
                 .mcp_servers_config
                 .to_json()
                 .unwrap_or_else(|_| "{}".to_string());
-            self.widget(id!(mcp_code_view)).set_text(cx, &display_json);
+            self.widget(ids!(mcp_code_view)).set_text(cx, &display_json);
 
             // Sync to Store
             let store = scope.data.get_mut::<Store>().unwrap();

--- a/src/my_models/delete_model_modal.rs
+++ b/src/my_models/delete_model_modal.rs
@@ -163,7 +163,7 @@ impl Widget for DeleteModelModal {
             "Are you sure you want to delete {}?\nThis action cannot be undone.",
             downloaded_file.file.name
         );
-        self.label(id!(wrapper.body.delete_prompt))
+        self.label(ids!(wrapper.body.delete_prompt))
             .set_text(cx, &prompt_text);
 
         self.view
@@ -173,12 +173,12 @@ impl Widget for DeleteModelModal {
 
 impl WidgetMatchEvent for DeleteModelModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(DeleteModelModalAction::ModalDismissed);
         }
 
         if self
-            .button(id!(wrapper.body.actions.delete_button))
+            .button(ids!(wrapper.body.actions.delete_button))
             .clicked(actions)
         {
             let store = scope.data.get_mut::<Store>().unwrap();
@@ -189,7 +189,7 @@ impl WidgetMatchEvent for DeleteModelModal {
         }
 
         if self
-            .button(id!(wrapper.body.actions.cancel_button))
+            .button(ids!(wrapper.body.actions.cancel_button))
             .clicked(actions)
         {
             cx.action(DeleteModelModalAction::ModalDismissed);

--- a/src/my_models/downloaded_files_row.rs
+++ b/src/my_models/downloaded_files_row.rs
@@ -206,43 +206,39 @@ impl Widget for DownloadedFilesRow {
 
         // Name tag
         let name = human_readable_name(&downloaded_file.file.name);
-        self.label(id!(h_wrapper.model_file.h_wrapper.name_tag.name))
+        self.label(ids!(h_wrapper.model_file.h_wrapper.name_tag.name))
             .set_text(cx, &name);
 
         // Base model tag
         let base_model = dash_if_empty(&downloaded_file.model.architecture);
-        self.label(id!(h_wrapper
-            .model_file
-            .base_model_tag
-            .base_model
-            .attr_name))
-            .set_text(cx, &base_model);
+        self.label(ids!(
+            h_wrapper.model_file.base_model_tag.base_model.attr_name
+        ))
+        .set_text(cx, &base_model);
 
         // Parameters tag
         let parameters = dash_if_empty(&downloaded_file.model.size);
-        self.label(id!(h_wrapper
-            .model_file
-            .parameters_tag
-            .parameters
-            .attr_name))
-            .set_text(cx, &parameters);
+        self.label(ids!(
+            h_wrapper.model_file.parameters_tag.parameters.attr_name
+        ))
+        .set_text(cx, &parameters);
 
         // Version tag
         let filename = format!(
             "{}/{}",
             downloaded_file.model.name, downloaded_file.file.name
         );
-        self.label(id!(h_wrapper.model_file.model_version_tag.version))
+        self.label(ids!(h_wrapper.model_file.model_version_tag.version))
             .set_text(cx, &filename);
 
         // File size tag
         let file_size = format_model_size(&downloaded_file.file.size).unwrap_or("-".to_string());
-        self.label(id!(h_wrapper.file_size_tag.label))
+        self.label(ids!(h_wrapper.file_size_tag.label))
             .set_text(cx, &file_size);
 
         // Added date tag
         let formatted_date = downloaded_file.downloaded_at.format("%d/%m/%Y").to_string();
-        self.label(id!(h_wrapper.date_added_tag.label))
+        self.label(ids!(h_wrapper.date_added_tag.label))
             .set_text(cx, &formatted_date);
 
         self.view.draw_walk(cx, scope, walk)
@@ -251,7 +247,7 @@ impl Widget for DownloadedFilesRow {
 
 impl WidgetMatchEvent for DownloadedFilesRow {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(start_chat_button)).clicked(actions) {
+        if self.button(ids!(start_chat_button)).clicked(actions) {
             if let Some(file_id) = &self.file_id {
                 let store = scope.data.get_mut::<Store>().unwrap();
                 let bot_id = store.chats.get_bot_id_by_file_id(file_id);
@@ -261,21 +257,24 @@ impl WidgetMatchEvent for DownloadedFilesRow {
             }
         }
 
-        if self.button(id!(row_actions.info_button)).clicked(actions) {
-            self.modal(id!(info_modal)).open(cx);
+        if self.button(ids!(row_actions.info_button)).clicked(actions) {
+            self.modal(ids!(info_modal)).open(cx);
         }
 
-        if self.button(id!(row_actions.delete_button)).clicked(actions) {
-            self.modal(id!(delete_modal)).open(cx);
+        if self
+            .button(ids!(row_actions.delete_button))
+            .clicked(actions)
+        {
+            self.modal(ids!(delete_modal)).open(cx);
         }
 
         for action in actions {
             if let DeleteModelModalAction::ModalDismissed = action.cast() {
-                self.modal(id!(delete_modal)).close(cx);
+                self.modal(ids!(delete_modal)).close(cx);
             }
 
             if let ModelInfoModalAction::ModalDismissed = action.cast() {
-                self.modal(id!(info_modal)).close(cx);
+                self.modal(ids!(info_modal)).close(cx);
             }
         }
     }

--- a/src/my_models/model_info_modal.rs
+++ b/src/my_models/model_info_modal.rs
@@ -190,15 +190,15 @@ impl Widget for ModelInfoModal {
         self.model_id = downloaded_file.model.id.clone();
 
         // filename
-        self.label(id!(title.filename))
+        self.label(ids!(title.filename))
             .set_text(cx, &downloaded_file.file.name);
 
         // file path
         if let Some(path) = &downloaded_file.file.downloaded_path {
-            self.html(id!(file_dir.path))
+            self.html(ids!(file_dir.path))
                 .set_text(cx, &format!("<pre>{}</pre>", path));
         } else {
-            self.view(id!(file_dir)).set_visible(cx, false);
+            self.view(ids!(file_dir)).set_visible(cx, false);
         }
 
         // metadata
@@ -206,7 +206,7 @@ impl Widget for ModelInfoModal {
             .expect("Could not serialize model data into json");
         let metadata = format!("<pre>{}</pre>", self.stringified_model_data);
 
-        self.html(id!(wrapper.body.metadata))
+        self.html(ids!(wrapper.body.metadata))
             .set_text(cx, &metadata);
 
         self.view
@@ -216,19 +216,19 @@ impl Widget for ModelInfoModal {
 
 impl WidgetMatchEvent for ModelInfoModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(ModelInfoModalAction::ModalDismissed);
         }
 
         if self
-            .button(id!(wrapper.body.actions.copy_button))
+            .button(ids!(wrapper.body.actions.copy_button))
             .clicked(actions)
         {
             cx.copy_to_clipboard(&self.stringified_model_data);
         }
 
         if self
-            .button(id!(wrapper.body.actions.external_link))
+            .button(ids!(wrapper.body.actions.external_link))
             .clicked(actions)
         {
             let model_url = hugging_face_model_url(&self.model_id);

--- a/src/my_models/my_models_screen.rs
+++ b/src/my_models/my_models_screen.rs
@@ -188,11 +188,11 @@ impl Widget for MyModelsScreen {
             .downloaded_files;
 
         let summary = generate_models_summary(&downloaded_files);
-        let models_summary_label = self.view.label(id!(header.models_summary));
+        let models_summary_label = self.view.label(ids!(header.models_summary));
         models_summary_label.set_text(cx, &summary);
 
         self.view
-            .button(id!(show_in_files))
+            .button(ids!(show_in_files))
             .set_text(cx, &file_manager_label());
 
         self.view.draw_walk(cx, scope, walk)
@@ -211,7 +211,7 @@ fn file_manager_label() -> String {
 
 impl WidgetMatchEvent for MyModelsScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(show_in_files)).clicked(actions) {
+        if self.button(ids!(show_in_files)).clicked(actions) {
             let models_dir = &scope
                 .data
                 .get::<Store>()
@@ -231,7 +231,7 @@ impl WidgetMatchEvent for MyModelsScreen {
 
         // Commented out for now as we don't have a way to change the download location yet
         // and we don't know if we'll support it again.
-        // if self.button(id!(download_location)).clicked(actions) {
+        // if self.button(ids!(download_location)).clicked(actions) {
         //     let scope = &mut scope.data.get_mut::<Store>().unwrap();
         //     let models_dir = &scope.preferences.downloaded_files_dir;
         //     let models_uri = &format!("file:///{}", models_dir.display());
@@ -253,7 +253,7 @@ impl WidgetMatchEvent for MyModelsScreen {
         //     }
         // }
 
-        if let Some(keywords) = self.text_input(id!(search.input)).changed(actions) {
+        if let Some(keywords) = self.text_input(ids!(search.input)).changed(actions) {
             if !keywords.is_empty() {
                 cx.action(MyModelsSearchAction::Search(keywords.to_string()));
             } else {

--- a/src/settings/add_provider_modal.rs
+++ b/src/settings/add_provider_modal.rs
@@ -301,14 +301,14 @@ impl WidgetMatchEvent for AddProviderModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
 
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(AddProviderModalAction::ModalDismissed);
         }
 
-        if self.button(id!(add_server_button)).clicked(actions) {
+        if self.button(ids!(add_server_button)).clicked(actions) {
             self.clear_error_message(cx);
-            let api_host = self.text_input(id!(api_host)).text().trim().to_string();
-            let name = self.text_input(id!(name)).text().trim().to_string();
+            let api_host = self.text_input(ids!(api_host)).text().trim().to_string();
+            let name = self.text_input(ids!(name)).text().trim().to_string();
 
             // Check if the provider type is selected
             if self.selected_provider.is_none() {
@@ -322,7 +322,7 @@ impl WidgetMatchEvent for AddProviderModal {
                 return;
             }
 
-            let api_key = self.text_input(id!(api_key)).text().trim().to_string();
+            let api_key = self.text_input(ids!(api_key)).text().trim().to_string();
 
             // Generate a unique ID for the custom provider
             let provider_id = {
@@ -459,7 +459,7 @@ impl WidgetMatchEvent for AddProviderModal {
         }
 
         let selected = self
-            .radio_button_set(ids!(
+            .radio_button_set(ids_array!(
                 radios.radio_openai,
                 radios.radio_mofa,
                 radios.radio_deepinquire,
@@ -482,18 +482,18 @@ impl WidgetMatchEvent for AddProviderModal {
 
 impl AddProviderModal {
     fn set_error_message(&mut self, cx: &mut Cx, message: &str) {
-        self.view(id!(error_view)).set_visible(cx, true);
-        self.label(id!(error_message)).set_text(cx, message);
+        self.view(ids!(error_view)).set_visible(cx, true);
+        self.label(ids!(error_message)).set_text(cx, message);
     }
 
     fn clear_error_message(&mut self, cx: &mut Cx) {
-        self.label(id!(error_message)).set_text(cx, "");
-        self.view(id!(error_view)).set_visible(cx, false);
+        self.label(ids!(error_message)).set_text(cx, "");
+        self.view(ids!(error_view)).set_visible(cx, false);
     }
 
     fn clear_form(&mut self, cx: &mut Cx) {
-        self.text_input(id!(api_host)).set_text(cx, "");
-        self.text_input(id!(api_key)).set_text(cx, "");
+        self.text_input(ids!(api_host)).set_text(cx, "");
+        self.text_input(ids!(api_key)).set_text(cx, "");
         self.clear_error_message(cx);
         self.selected_provider = None;
     }

--- a/src/settings/moly_server_screen.rs
+++ b/src/settings/moly_server_screen.rs
@@ -202,11 +202,12 @@ impl Widget for MolyServerScreen {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         let store = scope.data.get_mut::<Store>().unwrap();
         if store.is_moly_server_connected() {
-            self.view(id!(server_not_accessible)).set_visible(cx, false);
-            self.view(id!(main_content)).set_visible(cx, true);
+            self.view(ids!(server_not_accessible))
+                .set_visible(cx, false);
+            self.view(ids!(main_content)).set_visible(cx, true);
         } else {
-            self.view(id!(server_not_accessible)).set_visible(cx, true);
-            self.view(id!(main_content)).set_visible(cx, false);
+            self.view(ids!(server_not_accessible)).set_visible(cx, true);
+            self.view(ids!(main_content)).set_visible(cx, false);
         }
 
         self.view.draw_walk(cx, scope, walk)
@@ -218,11 +219,11 @@ impl WidgetMatchEvent for MolyServerScreen {
         // RadioButton's selected_to_visible does not seem to work at this level
         // So we're manually checking the selected index and setting the visibility of the pages manually
         let selected_index = self
-            .radio_button_set(ids!(menu.discover_tab, menu.my_models_tab))
+            .radio_button_set(ids_array!(menu.discover_tab, menu.my_models_tab))
             .selected(cx, actions);
 
-        let discover_frame = self.view(id!(pages.discover_frame));
-        let my_models_frame = self.view(id!(pages.my_models_frame));
+        let discover_frame = self.view(ids!(pages.discover_frame));
+        let my_models_frame = self.view(ids!(pages.my_models_frame));
 
         match selected_index {
             Some(0) => {
@@ -238,10 +239,10 @@ impl WidgetMatchEvent for MolyServerScreen {
             _ => (),
         }
 
-        if self.button(id!(go_to_providers)).clicked(actions) {
+        if self.button(ids!(go_to_providers)).clicked(actions) {
             cx.action(NavigationAction::NavigateToProviders);
         }
-        if self.button(id!(refresh)).clicked(actions) {
+        if self.button(ids!(refresh)).clicked(actions) {
             let store = scope.data.get_mut::<Store>().unwrap();
             store.sync_with_moly_server();
         }

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -399,9 +399,9 @@ impl Widget for ProviderView {
         self.update_connection_status(cx);
 
         if self.provider.enabled {
-            self.view(id!(refresh_button)).set_visible(cx, true);
+            self.view(ids!(refresh_button)).set_visible(cx, true);
         } else {
-            self.view(id!(refresh_button)).set_visible(cx, false);
+            self.view(ids!(refresh_button)).set_visible(cx, false);
         }
 
         let entries_count = models.len();
@@ -415,12 +415,12 @@ impl Widget for ProviderView {
 
                         // hide the separator for the first item
                         if item_id == 0 {
-                            item.view(id!(separator)).set_visible(cx, false);
+                            item.view(ids!(separator)).set_visible(cx, false);
                         }
 
                         let name = models[item_id].human_readable_name();
-                        item.label(id!(model_name)).set_text(cx, &name);
-                        item.check_box(id!(enabled_switch))
+                        item.label(ids!(model_name)).set_text(cx, &name);
+                        item.check_box(ids!(enabled_switch))
                             .set_active(cx, models[item_id].enabled && self.provider.enabled);
 
                         item.as_model_entry().set_model_name(&models[item_id].name);
@@ -435,7 +435,7 @@ impl Widget for ProviderView {
 
 impl ProviderView {
     fn update_connection_status(&mut self, cx: &mut Cx) {
-        let connection_status_label = self.label(id!(connection_status));
+        let connection_status_label = self.label(ids!(connection_status));
         connection_status_label.set_text(cx, &self.provider.connection_status.to_human_readable());
         let text_color = match &self.provider.connection_status {
             ProviderConnectionStatus::Connected => {
@@ -470,7 +470,7 @@ impl WidgetMatchEvent for ProviderView {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         let store = scope.data.get_mut::<Store>().unwrap();
         // Handle provider enabled/disabled
-        let provider_enabled_switch = self.check_box(id!(provider_enabled_switch));
+        let provider_enabled_switch = self.check_box(ids!(provider_enabled_switch));
         if let Some(enabled) = provider_enabled_switch.changed(actions) {
             self.provider.enabled = enabled;
             // Update the provider in store and preferences
@@ -479,7 +479,7 @@ impl WidgetMatchEvent for ProviderView {
         }
 
         // Handle tools enabled/disabled
-        let provider_tools_switch = self.check_box(id!(provider_tools_switch));
+        let provider_tools_switch = self.check_box(ids!(provider_tools_switch));
         if let Some(tools_enabled) = provider_tools_switch.changed(actions) {
             self.provider.tools_enabled = tools_enabled;
             // Update the provider in store and preferences
@@ -514,14 +514,19 @@ impl WidgetMatchEvent for ProviderView {
         }
 
         // Handle save
-        if self.button(id!(save_provider)).clicked(actions) {
+        if self.button(ids!(save_provider)).clicked(actions) {
             self.provider.url = self
                 .view
-                .text_input(id!(api_host))
+                .text_input(ids!(api_host))
                 .text()
                 .trim()
                 .to_string();
-            let api_key = self.view.text_input(id!(api_key)).text().trim().to_string();
+            let api_key = self
+                .view
+                .text_input(ids!(api_key))
+                .text()
+                .trim()
+                .to_string();
             if api_key.is_empty() {
                 self.provider.api_key = None;
             } else {
@@ -532,7 +537,7 @@ impl WidgetMatchEvent for ProviderView {
             if self.provider.provider_type == ProviderType::OpenAIRealtime {
                 let system_prompt = self
                     .view
-                    .text_input(id!(system_prompt))
+                    .text_input(ids!(system_prompt))
                     .text()
                     .trim()
                     .to_string();
@@ -547,7 +552,7 @@ impl WidgetMatchEvent for ProviderView {
             self.provider.enabled = true;
             // Clear any previous error state and set to connecting
             self.provider.connection_status = ProviderConnectionStatus::Connecting;
-            self.check_box(id!(provider_enabled_switch))
+            self.check_box(ids!(provider_enabled_switch))
                 .set_active(cx, true);
             // Keep the tools_enabled state as set by the user (don't change it on save)
 
@@ -560,7 +565,7 @@ impl WidgetMatchEvent for ProviderView {
         }
 
         // Handle refresh button
-        if let Some(_fe) = self.view(id!(refresh_button)).finger_up(actions) {
+        if let Some(_fe) = self.view(ids!(refresh_button)).finger_up(actions) {
             // Clear any previous error state and set to connecting
             self.provider.connection_status = ProviderConnectionStatus::Connecting;
 
@@ -573,7 +578,7 @@ impl WidgetMatchEvent for ProviderView {
         }
 
         // Handle remove provider button
-        if self.button(id!(remove_provider_button)).clicked(actions) {
+        if self.button(ids!(remove_provider_button)).clicked(actions) {
             store.remove_provider(&self.provider.id);
             cx.action(ProviderViewAction::ProviderRemoved);
             self.redraw(cx);
@@ -587,51 +592,53 @@ impl ProviderViewRef {
             inner.provider = provider.clone();
 
             // Update the text inputs
-            let api_key_input = inner.text_input(id!(api_key));
+            let api_key_input = inner.text_input(ids!(api_key));
             if let Some(api_key) = &provider.api_key {
                 api_key_input.set_text(cx, &api_key);
             } else {
                 api_key_input.set_text(cx, "");
             }
 
-            inner.text_input(id!(api_host)).set_text(cx, &provider.url);
-            inner.label(id!(name)).set_text(cx, &provider.name);
+            inner.text_input(ids!(api_host)).set_text(cx, &provider.url);
+            inner.label(ids!(name)).set_text(cx, &provider.name);
             inner
-                .label(id!(provider_type))
+                .label(ids!(provider_type))
                 .set_text(cx, &provider.provider_type.to_human_readable());
             inner
-                .check_box(id!(provider_enabled_switch))
+                .check_box(ids!(provider_enabled_switch))
                 .set_active(cx, provider.enabled);
             inner
-                .check_box(id!(provider_tools_switch))
+                .check_box(ids!(provider_tools_switch))
                 .set_active(cx, provider.tools_enabled);
 
             // Show/hide system prompt field for Realtime providers
             if provider.provider_type == ProviderType::OpenAIRealtime {
-                inner.view(id!(system_prompt_group)).set_visible(cx, true);
+                inner.view(ids!(system_prompt_group)).set_visible(cx, true);
                 if let Some(system_prompt) = &provider.system_prompt {
                     inner
-                        .text_input(id!(system_prompt))
+                        .text_input(ids!(system_prompt))
                         .set_text(cx, &system_prompt);
                 } else {
-                    inner.text_input(id!(system_prompt)).set_text(cx, "");
+                    inner.text_input(ids!(system_prompt)).set_text(cx, "");
                 }
             } else {
-                inner.view(id!(system_prompt_group)).set_visible(cx, false);
+                inner.view(ids!(system_prompt_group)).set_visible(cx, false);
             }
 
             if provider.provider_type == ProviderType::OpenAIRealtime
                 || provider.provider_type == ProviderType::OpenAI
             {
-                inner.view(id!(tools_form_group)).set_visible(cx, true);
+                inner.view(ids!(tools_form_group)).set_visible(cx, true);
             } else {
-                inner.view(id!(tools_form_group)).set_visible(cx, false);
+                inner.view(ids!(tools_form_group)).set_visible(cx, false);
             }
 
             if provider.was_customly_added {
-                inner.view(id!(remove_provider_view)).set_visible(cx, true);
+                inner.view(ids!(remove_provider_view)).set_visible(cx, true);
             } else {
-                inner.view(id!(remove_provider_view)).set_visible(cx, false);
+                inner
+                    .view(ids!(remove_provider_view))
+                    .set_visible(cx, false);
             }
 
             inner.view.redraw(cx);
@@ -690,7 +697,7 @@ impl Widget for ModelEntry {
 impl WidgetMatchEvent for ModelEntry {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
         // Handle the enabled switch
-        let enabled_switch = self.check_box(id!(enabled_switch));
+        let enabled_switch = self.check_box(ids!(enabled_switch));
         if let Some(change) = enabled_switch.changed(actions) {
             cx.action(ModelEntryAction::ModelEnabledChanged(
                 self.model_name.clone(),

--- a/src/settings/providers.rs
+++ b/src/settings/providers.rs
@@ -296,7 +296,7 @@ impl Widget for Providers {
 
                         // hide the separator for the first item
                         if item_id == 0 {
-                            item.view(id!(separator)).set_visible(cx, false);
+                            item.view(ids!(separator)).set_visible(cx, false);
                         }
 
                         let provider = all_providers[item_id].clone();
@@ -332,20 +332,20 @@ impl WidgetMatchEvent for Providers {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
         // Handle modal open
         if self
-            .view(id!(add_provider_button))
+            .view(ids!(add_provider_button))
             .finger_up(actions)
             .is_some()
         {
-            let modal = self.modal(id!(add_provider_modal));
+            let modal = self.modal(ids!(add_provider_modal));
             modal.open(cx);
         }
 
         if self
-            .view(id!(open_sync_button))
+            .view(ids!(open_sync_button))
             .finger_up(actions)
             .is_some()
         {
-            let modal = self.modal(id!(sync_modal));
+            let modal = self.modal(ids!(sync_modal));
             modal.open(cx);
         }
 
@@ -357,20 +357,20 @@ impl WidgetMatchEvent for Providers {
 
             // Handle modal actions
             if let AddProviderModalAction::ModalDismissed = action.cast() {
-                self.modal(id!(add_provider_modal)).close(cx);
+                self.modal(ids!(add_provider_modal)).close(cx);
                 self.redraw(cx);
             }
 
             if let SyncModalAction::ModalDismissed = action.cast() {
-                self.modal(id!(sync_modal)).close(cx);
+                self.modal(ids!(sync_modal)).close(cx);
                 self.redraw(cx);
             }
 
             // Handle the case where the modal is dismissed by the user clicking outside the modal
             // This is a hacky way to reset the modal state because the inner content never gets to
             // hear if it was dismissed from outside.
-            if self.modal(id!(sync_modal)).dismissed(actions) {
-                self.sync_modal(id!(sync_modal_inner)).reset_state(cx);
+            if self.modal(ids!(sync_modal)).dismissed(actions) {
+                self.sync_modal(ids!(sync_modal_inner)).reset_state(cx);
             }
 
             // Handle provider removed
@@ -406,14 +406,14 @@ impl Widget for ProviderItem {
 
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         // Update the label
-        self.label(id!(provider_name_label))
+        self.label(ids!(provider_name_label))
             .set_text(cx, &self.provider.name);
 
         let connection_status = self.provider.connection_status.clone();
         // Show connection status icons
         self.update_connection_status(cx, &connection_status);
 
-        self.view(id!(status_view)).set_visible(
+        self.view(ids!(status_view)).set_visible(
             cx,
             connection_status == ProviderConnectionStatus::Connected && self.provider.enabled,
         );
@@ -424,7 +424,7 @@ impl Widget for ProviderItem {
 
 impl WidgetMatchEvent for ProviderItem {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if let Some(finger_up) = self.view(id!(main_view)).finger_up(actions) {
+        if let Some(finger_up) = self.view(ids!(main_view)).finger_up(actions) {
             if finger_up.was_tap() {
                 cx.action(ConnectionSettingsAction::ProviderSelected(
                     self.provider.id.clone(),
@@ -441,15 +441,15 @@ impl ProviderItem {
         cx: &mut Cx,
         connection_status: &ProviderConnectionStatus,
     ) {
-        self.view(id!(connection_status_success)).set_visible(
+        self.view(ids!(connection_status_success)).set_visible(
             cx,
             *connection_status == ProviderConnectionStatus::Connected,
         );
-        self.view(id!(connection_status_failure)).set_visible(
+        self.view(ids!(connection_status_failure)).set_visible(
             cx,
             *connection_status == ProviderConnectionStatus::Disconnected,
         );
-        self.view(id!(connection_status_loading)).set_visible(
+        self.view(ids!(connection_status_loading)).set_visible(
             cx,
             *connection_status == ProviderConnectionStatus::Connecting,
         );
@@ -472,19 +472,19 @@ impl ProviderItemRef {
         // Determine whether to show image or label
         if let Some(icon) = icon_path {
             // Show the image
-            inner.view(id!(image_wrapper)).set_visible(cx, true);
-            let image = inner.image(id!(provider_icon_image));
+            inner.view(ids!(image_wrapper)).set_visible(cx, true);
+            let image = inner.image(ids!(provider_icon_image));
             let _ = image.load_image_dep_by_path(cx, icon.as_str());
 
             // Hide the label
-            let label_view = inner.view(id!(provider_icon_label));
+            let label_view = inner.view(ids!(provider_icon_label));
             label_view.set_visible(cx, false);
         } else {
             // Hide the image
-            inner.view(id!(image_wrapper)).set_visible(cx, false);
+            inner.view(ids!(image_wrapper)).set_visible(cx, false);
 
             // Show the label
-            let label_view = inner.view(id!(label_wrapper));
+            let label_view = inner.view(ids!(label_wrapper));
             label_view.set_visible(cx, true);
 
             // Get first character of the provider name
@@ -496,7 +496,7 @@ impl ProviderItemRef {
                 .unwrap_or_default();
 
             label_view
-                .label(id!(initial_label))
+                .label(ids!(initial_label))
                 .set_text(cx, &first_char);
         }
 

--- a/src/settings/providers_screen.rs
+++ b/src/settings/providers_screen.rs
@@ -90,7 +90,7 @@ impl Widget for ProvidersScreen {
 
 impl WidgetMatchEvent for ProvidersScreen {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        let stack_navigation = self.stack_navigation(id!(navigation));
+        let stack_navigation = self.stack_navigation(ids!(navigation));
         stack_navigation.handle_stack_view_actions(cx, actions);
 
         for action in actions {
@@ -105,7 +105,7 @@ impl WidgetMatchEvent for ProvidersScreen {
                     .get(&provider_id);
                 if let Some(provider) = provider {
                     self.view
-                        .provider_view(id!(provider_view))
+                        .provider_view(ids!(provider_view))
                         .set_provider(cx, provider);
                 } else {
                     eprintln!("Provider not found: {}", provider_id);

--- a/src/settings/sync_modal.rs
+++ b/src/settings/sync_modal.rs
@@ -354,9 +354,9 @@ impl Widget for SyncModal {
     fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
         #[cfg(target_arch = "wasm32")]
         {
-            self.view(id!(sync_buttons)).set_visible(cx, false);
-            self.view(id!(import_view)).set_visible(cx, true);
-            self.label(id!(hint))
+            self.view(ids!(sync_buttons)).set_visible(cx, false);
+            self.view(ids!(import_view)).set_visible(cx, true);
+            self.label(ids!(hint))
                 .set_text(cx, "Import your settings from another Moly instance");
         }
 
@@ -367,34 +367,34 @@ impl Widget for SyncModal {
 
 impl WidgetMatchEvent for SyncModal {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             self.reset_state(cx);
             cx.action(SyncModalAction::ModalDismissed);
         }
 
-        if self.view(id!(serve)).finger_down(actions).is_some() {
+        if self.view(ids!(serve)).finger_down(actions).is_some() {
             self.show_export(cx);
             if let SyncStatus::None = self.sync_status {
                 self.serve(cx, scope);
             }
         }
 
-        if self.view(id!(stop_server)).finger_down(actions).is_some() {
+        if self.view(ids!(stop_server)).finger_down(actions).is_some() {
             self.stop_server(cx);
         }
 
-        if self.view(id!(show_import)).finger_down(actions).is_some() {
+        if self.view(ids!(show_import)).finger_down(actions).is_some() {
             self.show_import(cx);
         }
 
-        if self.view(id!(import)).finger_down(actions).is_some() {
+        if self.view(ids!(import)).finger_down(actions).is_some() {
             if let SyncStatus::None = self.sync_status {
                 self.import();
             }
         }
 
         if let Some(selected_sync_mode) = self
-            .radio_button_set(ids!(radios.radio_merge, radios.radio_replace))
+            .radio_button_set(ids_array!(radios.radio_merge, radios.radio_replace))
             .selected(cx, actions)
         {
             self.should_merge = match selected_sync_mode {
@@ -403,7 +403,8 @@ impl WidgetMatchEvent for SyncModal {
                 _ => true,
             };
         } else {
-            self.radio_button(id!(radios.radio_merge)).select(cx, scope);
+            self.radio_button(ids!(radios.radio_merge))
+                .select(cx, scope);
         }
     }
 }
@@ -423,21 +424,21 @@ impl SyncModal {
                     ::log::info!("Sync server started at {:?}", addr);
                     ui.defer_with_redraw(move |me, cx, _| {
                         me.sync_status = SyncStatus::Serving;
-                        me.label(id!(sync_pin)).set_text(cx, &server_handle.pin);
+                        me.label(ids!(sync_pin)).set_text(cx, &server_handle.pin);
                         me.server_handle = Some(server_handle);
 
                         let full_server_url =
                             format!("http://{}:{}", get_local_ip_address(), addr.port());
-                        me.label(id!(serving_url)).set_text(cx, &full_server_url);
+                        me.label(ids!(serving_url)).set_text(cx, &full_server_url);
                     });
                 }
                 Err(e) => {
                     ::log::error!("Failed to start sync server: {}", e);
                     ui.defer_with_redraw(move |me, cx, _| {
                         me.sync_status = SyncStatus::None;
-                        me.label(id!(status_message))
+                        me.label(ids!(status_message))
                             .set_text(cx, &format!("Failed to start server: {}", e));
-                        me.view(id!(status_view)).set_visible(cx, true);
+                        me.view(ids!(status_view)).set_visible(cx, true);
                     });
                 }
             }
@@ -451,7 +452,7 @@ impl SyncModal {
             ::log::info!("Sync server stopped");
         }
         self.sync_status = SyncStatus::None;
-        self.view(id!(export_view)).set_visible(cx, false);
+        self.view(ids!(export_view)).set_visible(cx, false);
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -465,18 +466,18 @@ impl SyncModal {
     }
 
     fn show_export(&mut self, cx: &mut Cx) {
-        self.view(id!(import_view)).set_visible(cx, false);
-        self.view(id!(export_view)).set_visible(cx, true);
+        self.view(ids!(import_view)).set_visible(cx, false);
+        self.view(ids!(export_view)).set_visible(cx, true);
     }
 
     fn show_import(&mut self, cx: &mut Cx) {
-        self.view(id!(import_view)).set_visible(cx, true);
-        self.view(id!(export_view)).set_visible(cx, false);
+        self.view(ids!(import_view)).set_visible(cx, true);
+        self.view(ids!(export_view)).set_visible(cx, false);
     }
 
     fn import(&mut self) {
-        let url = self.text_input(id!(import_view.import_url)).text();
-        let pin = self.text_input(id!(import_view.import_pin)).text();
+        let url = self.text_input(ids!(import_view.import_url)).text();
+        let pin = self.text_input(ids!(import_view.import_pin)).text();
 
         let ui = self.ui_runner();
         self.sync_status = SyncStatus::Importing;
@@ -498,9 +499,9 @@ impl SyncModal {
     }
 
     fn handle_import_success(&mut self, cx: &mut Cx, json: &str, scope: &mut Scope) {
-        self.view(id!(status_view)).set_visible(cx, true);
+        self.view(ids!(status_view)).set_visible(cx, true);
         self.sync_status = SyncStatus::None;
-        let include_mcp_servers = self.check_box(id!(include_mcp_servers)).active(cx);
+        let include_mcp_servers = self.check_box(ids!(include_mcp_servers)).active(cx);
 
         let store = scope.data.get_mut::<Store>().unwrap();
         match store
@@ -508,7 +509,7 @@ impl SyncModal {
             .import_from_json(json, self.should_merge, include_mcp_servers)
         {
             Ok(_) => {
-                self.label(id!(status_message))
+                self.label(ids!(status_message))
                     .set_text(cx, "Import successful");
                 store.bot_context = None;
                 store.load_preference_connections();
@@ -522,7 +523,7 @@ impl SyncModal {
             }
             Err(e) => {
                 ::log::error!("Failed to import: {}", e);
-                self.label(id!(status_message))
+                self.label(ids!(status_message))
                     .set_text(cx, "Failed to import");
             }
         }
@@ -530,16 +531,16 @@ impl SyncModal {
 
     fn handle_import_error(&mut self, cx: &mut Cx, error: Error) {
         ::log::error!("Failed to fetch settings: {:?}", error);
-        self.view(id!(status_view)).set_visible(cx, true);
-        self.label(id!(status_message))
+        self.view(ids!(status_view)).set_visible(cx, true);
+        self.label(ids!(status_message))
             .set_text(cx, &format!("Failed to fetch settings: {:?}", error));
     }
 
     fn reset_state(&mut self, cx: &mut Cx) {
-        self.view(id!(export_view)).set_visible(cx, false);
-        self.view(id!(import_view)).set_visible(cx, false);
-        self.view(id!(status_view)).set_visible(cx, false);
-        self.label(id!(status_message)).set_text(cx, "");
+        self.view(ids!(export_view)).set_visible(cx, false);
+        self.view(ids!(import_view)).set_visible(cx, false);
+        self.view(ids!(status_view)).set_visible(cx, false);
+        self.label(ids!(status_message)).set_text(cx, "");
         self.sync_status = SyncStatus::None;
         self.stop_server(cx);
     }

--- a/src/shared/download_notification_popup.rs
+++ b/src/shared/download_notification_popup.rs
@@ -243,25 +243,25 @@ impl Widget for DownloadNotificationPopup {
 
 impl WidgetMatchEvent for DownloadNotificationPopup {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(DownloadNotificationPopupAction::CloseButtonClicked);
         }
 
         if self
-            .link_label(id!(view_in_my_models_link))
+            .link_label(ids!(view_in_my_models_link))
             .clicked(actions)
         {
             cx.action(NavigationAction::NavigateToMyModels);
             cx.action(DownloadNotificationPopupAction::ActionLinkClicked);
         }
 
-        if self.link_label(id!(retry_link)).clicked(actions) {
+        if self.link_label(ids!(retry_link)).clicked(actions) {
             let Some(file_id) = &self.file_id else { return };
             cx.action(DownloadAction::Play(file_id.clone()));
             cx.action(DownloadNotificationPopupAction::ActionLinkClicked);
         }
 
-        if self.link_label(id!(cancel_link)).clicked(actions) {
+        if self.link_label(ids!(cancel_link)).clicked(actions) {
             let Some(file_id) = &self.file_id else { return };
             cx.action(DownloadAction::Cancel(file_id.clone()));
             cx.action(DownloadNotificationPopupAction::ActionLinkClicked);
@@ -278,30 +278,30 @@ impl DownloadNotificationPopup {
     }
 
     fn show_success_content(&mut self, cx: &mut Cx) {
-        self.view(id!(success_icon)).set_visible(cx, true);
-        self.view(id!(failure_icon)).set_visible(cx, false);
+        self.view(ids!(success_icon)).set_visible(cx, true);
+        self.view(ids!(failure_icon)).set_visible(cx, false);
 
-        self.view(id!(success_actions)).set_visible(cx, true);
-        self.view(id!(failure_actions)).set_visible(cx, false);
+        self.view(ids!(success_actions)).set_visible(cx, true);
+        self.view(ids!(failure_actions)).set_visible(cx, false);
 
-        self.label(id!(title))
+        self.label(ids!(title))
             .set_text(cx, "Model Downloaded Successfully");
 
-        self.label(id!(summary))
+        self.label(ids!(summary))
             .set_text(cx, &(format!("{} successfuly downloaded.", &self.filename)));
     }
 
     fn show_failure_content(&mut self, cx: &mut Cx) {
-        self.view(id!(success_icon)).set_visible(cx, false);
-        self.view(id!(failure_icon)).set_visible(cx, true);
+        self.view(ids!(success_icon)).set_visible(cx, false);
+        self.view(ids!(failure_icon)).set_visible(cx, true);
 
-        self.view(id!(success_actions)).set_visible(cx, false);
-        self.view(id!(failure_actions)).set_visible(cx, true);
+        self.view(ids!(success_actions)).set_visible(cx, false);
+        self.view(ids!(failure_actions)).set_visible(cx, true);
 
-        self.label(id!(title))
+        self.label(ids!(title))
             .set_text(cx, "Errors while downloading models");
 
-        self.label(id!(summary)).set_text(
+        self.label(ids!(summary)).set_text(
             cx,
             &(format!(
                 "{} encountered some errors when downloading.",
@@ -311,14 +311,14 @@ impl DownloadNotificationPopup {
     }
 
     pub fn show_retry_content(&mut self, cx: &mut Cx) {
-        let content = self.label(id!(summary));
-        self.view(id!(success_icon)).set_visible(cx, false);
-        self.view(id!(failure_icon)).set_visible(cx, true);
+        let content = self.label(ids!(summary));
+        self.view(ids!(success_icon)).set_visible(cx, false);
+        self.view(ids!(failure_icon)).set_visible(cx, true);
 
-        self.view(id!(success_actions)).set_visible(cx, false);
-        self.view(id!(failure_actions)).set_visible(cx, false);
+        self.view(ids!(success_actions)).set_visible(cx, false);
+        self.view(ids!(failure_actions)).set_visible(cx, false);
 
-        self.label(id!(title)).set_text(cx, "Retry");
+        self.label(ids!(title)).set_text(cx, "Retry");
 
         match self.count {
             0 => {

--- a/src/shared/external_link.rs
+++ b/src/shared/external_link.rs
@@ -63,7 +63,7 @@ impl Widget for ExternalLink {
 
 impl WidgetMatchEvent for ExternalLink {
     fn handle_actions(&mut self, _cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        let link_label_clicked = self.link_label(id!(link)).clicked(actions);
+        let link_label_clicked = self.link_label(ids!(link)).clicked(actions);
         if link_label_clicked {
             self.open_url();
         }

--- a/src/shared/moly_server_popup.rs
+++ b/src/shared/moly_server_popup.rs
@@ -146,7 +146,7 @@ impl Widget for MolyServerPopup {
 
 impl WidgetMatchEvent for MolyServerPopup {
     fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
-        if self.button(id!(close_button)).clicked(actions) {
+        if self.button(ids!(close_button)).clicked(actions) {
             cx.action(MolyServerPopupAction::CloseButtonClicked);
         }
     }

--- a/src/shared/tooltip.rs
+++ b/src/shared/tooltip.rs
@@ -97,7 +97,7 @@ impl Widget for Tooltip {
     }
 
     fn set_text(&mut self, cx: &mut Cx, text: &str) {
-        self.label(id!(tooltip_label)).set_text(cx, text);
+        self.label(ids!(tooltip_label)).set_text(cx, text);
     }
 }
 


### PR DESCRIPTION
Catches up with makepad changes to the live id macros.
As per Rik's comment:
> ids!() to ids_array!() (do that first)
> then id!() to ids!()
> id!() is now one LiveId and ids! is &[LiveId] and ids_array is &[&[LiveId]]