### PR TITLE
Improve ProviderView usability for mobile

### DIFF
--- a/src/settings/providers_screen.rs
+++ b/src/settings/providers_screen.rs
@@ -63,6 +63,11 @@ live_design! {
 
             Mobile = {
                 providers = <Providers> {
+                    providers_list = {
+                        provider_item = {
+                            height: 45
+                        }
+                    }
                     width: Fill, height: Fill
                     padding: {left: 8, right: 8, top: 0, bottom: 0}
                 }


### PR DESCRIPTION
Closes #584

Makes the whole ProviderVIew scrollable, so that navigating through the settings and the models is easier in mobile screens.
Replaced `PortalList` with `FlatList` due to issues with event handling, and no need for virtualization.