### PR TITLE
Add in-app update notification popup and async startup updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,45 @@ jobs:
           cargo +stable install --force --locked cargo-packager
 
       - name: Build
+        env:
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY: ${{ secrets.CARGO_PACKAGER_SIGNING_KEY }}
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.CARGO_PACKAGER_SIGNING_PASSWORD }}
         run: |
           cargo packager --release --verbose
           ls dist/
+
+      - name: Generate updater manifest
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tags }}
+        run: |
+          set -euo pipefail
+          VERSION=$(cargo metadata --no-deps --format-version 1 --frozen --manifest-path Cargo.toml | jq -r '.packages[0].version')
+          cd dist
+          ARCH=$(uname -m)
+          # Normalize arch to updater naming
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH="x86_64"
+          elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+            ARCH="aarch64"
+          fi
+
+          APPIMAGE=$(ls moly_*.AppImage | head -n 1)
+          SIG_FILE="${APPIMAGE}.sig"
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "Missing signature file: $SIG_FILE" >&2
+            exit 1
+          fi
+
+          SIG_JSON=$(jq -Rs . < "$SIG_FILE")
+          ASSET_NAME=$(basename "$APPIMAGE")
+          cat > "latest-linux-${ARCH}.json" <<EOF
+          {
+            "version": "${VERSION}",
+            "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET_NAME}",
+            "signature": ${SIG_JSON},
+            "format": "appimage"
+          }
+          EOF
 
       - name: Upload Dist
         env:
@@ -79,6 +115,8 @@ jobs:
           gh release upload ${{ github.event.inputs.release_tags }} moly_*.deb --clobber
           gh release upload ${{ github.event.inputs.release_tags }} moly_*.tar.gz --clobber
           gh release upload ${{ github.event.inputs.release_tags }} moly_*.AppImage --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} *.sig --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} latest-linux-*.json --clobber
 
   build_macos:
     name: MacOS
@@ -105,9 +143,44 @@ jobs:
           cargo +stable install --force --locked cargo-packager
 
       - name: Build
+        env:
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY: ${{ secrets.CARGO_PACKAGER_SIGNING_KEY }}
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.CARGO_PACKAGER_SIGNING_PASSWORD }}
         run: |
-          cargo packager --release --verbose
+          cargo packager --release --verbose --formats "app,dmg"
           ls dist/
+
+      - name: Generate updater manifest
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tags }}
+        run: |
+          set -euo pipefail
+          VERSION=$(cargo metadata --no-deps --format-version 1 --frozen --manifest-path Cargo.toml | jq -r '.packages[0].version')
+          cd dist
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "arm64" ]; then
+            ARCH="aarch64"
+          elif [ "$ARCH" = "x86_64" ]; then
+            ARCH="x86_64"
+          fi
+
+          APP_ARCHIVE=$(ls *.app.tar.gz | head -n 1)
+          SIG_FILE="${APP_ARCHIVE}.sig"
+          if [ ! -f "$SIG_FILE" ]; then
+            echo "Missing signature file: $SIG_FILE" >&2
+            exit 1
+          fi
+
+          SIG_JSON=$(jq -Rs . < "$SIG_FILE")
+          ASSET_NAME=$(basename "$APP_ARCHIVE")
+          cat > "latest-macos-${ARCH}.json" <<EOF
+          {
+            "version": "${VERSION}",
+            "url": "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET_NAME}",
+            "signature": ${SIG_JSON},
+            "format": "app"
+          }
+          EOF
 
       - name: Upload Dist
         env:
@@ -115,6 +188,9 @@ jobs:
         run: |
           cd dist/
           gh release upload ${{ github.event.inputs.release_tags }} Moly_*.dmg --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} *.app.tar.gz --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} *.sig --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} latest-macos-*.json --clobber
 
   build_windows:
     name: Windows
@@ -139,9 +215,37 @@ jobs:
           cargo +stable install --force --locked cargo-packager
 
       - name: Build
+        env:
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY: ${{ secrets.CARGO_PACKAGER_SIGNING_KEY }}
+          CARGO_PACKAGER_SIGN_PRIVATE_KEY_PASSWORD: ${{ secrets.CARGO_PACKAGER_SIGNING_PASSWORD }}
         run: |
           cargo packager --release --formats nsis --verbose
           ls dist/
+
+      - name: Generate updater manifest
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.release_tags }}
+        shell: pwsh
+        run: |
+          Set-StrictMode -Version Latest
+          $VERSION = (cargo metadata --no-deps --format-version 1 --frozen | ConvertFrom-Json).packages[0].version
+          $Arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "aarch64" } else { "x86_64" }
+
+          Set-Location dist
+          $installer = Get-ChildItem -Filter *.exe | Select-Object -First 1
+          if (-not $installer) { throw "No nsis installer found" }
+          $sigPath = "$($installer.Name).sig"
+          if (-not (Test-Path $sigPath)) { throw "Missing signature file: $sigPath" }
+
+          $signature = Get-Content -Raw $sigPath
+          $manifest = [ordered]@{
+            version   = $VERSION
+            url       = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$env:RELEASE_TAG/$($installer.Name)"
+            signature = $signature
+            format    = "nsis"
+          } | ConvertTo-Json -Compress
+          $manifestPath = "latest-windows-$Arch.json"
+          $manifest | Out-File -FilePath $manifestPath -Encoding utf8
       - name: Upload Dist
         env:
           GITHUB_TOKEN: ${{ secrets.MOLY_RELEASE }}
@@ -149,6 +253,8 @@ jobs:
           cd dist/
           $file=Get-ChildItem -Filter *.exe
           gh release upload ${{ github.event.inputs.release_tags }} $file.name --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} *.sig --clobber
+          gh release upload ${{ github.event.inputs.release_tags }} latest-windows-*.json --clobber
   
   build_android:
     name: Android

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,6 +658,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-packager-updater"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec09acab5c2227aba2e592d431708305bdeb6d507703f6cd8983fb57b6c5ef7"
+dependencies = [
+ "base64",
+ "cargo-packager-utils",
+ "ctor",
+ "dirs",
+ "dunce",
+ "flate2",
+ "http",
+ "log",
+ "minisign-verify",
+ "percent-encoding",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "thiserror 1.0.69",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "cargo-packager-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b43458dd2ee3cdab3f5b105acd80791383b730380c929018701313d7d299d4e8"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1072,15 @@ name = "directories"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
  "dirs-sys",
 ]
@@ -1126,6 +1180,12 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -1429,6 +1489,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1923,6 +1995,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2761,6 +2834,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2866,7 @@ version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-fs",
+ "cargo-packager-updater",
  "cfg-if",
  "chrono",
  "directories",
@@ -3030,6 +3110,12 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -3390,6 +3476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,6 +3755,12 @@ checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3986,6 +4084,7 @@ checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -4000,6 +4099,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4237,6 +4337,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,6 +4388,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4337,6 +4458,29 @@ version = "0.2.1"
 source = "git+https://github.com/wyeworks/makepad?rev=b8b65f4fa#b8b65f4fa7e4814b0690c22ca65fa67f38812632"
 
 [[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "selectors"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4354,6 +4498,12 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -4690,6 +4840,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4699,7 +4860,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4765,6 +4926,37 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -5904,6 +6096,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -5950,11 +6151,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5985,6 +6203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6001,6 +6225,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6021,10 +6251,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6045,6 +6287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6061,6 +6309,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6081,6 +6335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6097,6 +6357,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
@@ -6197,6 +6463,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.0.7",
+]
 
 [[package]]
 name = "xcursor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ log = "0.4"
 env_logger = "0.11"
 cfg-if = "1.0.0"
 uuid = { version = "1.18.0", features = ["js", "v7"] }
+cargo-packager-updater = "0.2.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "signal"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ pub mod app;
 pub mod capture;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod runtime;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod updater;
 
 mod chat;
 mod data;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -11,6 +11,7 @@ pub mod moly_server_popup;
 pub mod popup_notification;
 pub mod resource_imports;
 pub mod styles;
+pub mod update_notification_popup;
 pub mod tooltip;
 pub mod utils;
 pub mod widgets;
@@ -24,6 +25,7 @@ pub fn live_design(cx: &mut Cx) {
     popup_notification::live_design(cx);
     external_link::live_design(cx);
     download_notification_popup::live_design(cx);
+    update_notification_popup::live_design(cx);
     tooltip::live_design(cx);
     desktop_buttons::live_design(cx);
     moly_server_popup::live_design(cx);

--- a/src/shared/update_notification_popup.rs
+++ b/src/shared/update_notification_popup.rs
@@ -1,0 +1,207 @@
+use makepad_widgets::*;
+
+live_design! {
+    use link::theme::*;
+    use link::shaders::*;
+    use link::widgets::*;
+
+    use crate::shared::styles::*;
+    use crate::shared::resource_imports::*;
+    use crate::shared::widgets::MolyButton;
+
+    UPDATE_ICON = dep("crate://self/resources/images/failure_icon.png")
+
+    UpdatePopupDialog = <RoundedView> {
+        width: 350
+        height: Fit
+        margin: {top: 20, right: 20}
+        padding: {top: 20, right: 20 bottom: 20 left: 20}
+        spacing: 15
+
+        show_bg: true
+        draw_bg: {
+            color: #fff
+            instance border_radius: 4.0
+            fn pixel(self) -> vec4 {
+                let border_color = #d4;
+                let border_width = 1;
+                let sdf = Sdf2d::viewport(self.pos * self.rect_size);
+                let body = #fff
+
+                sdf.box(
+                    1.,
+                    1.,
+                    self.rect_size.x - 2.0,
+                    self.rect_size.y - 2.0,
+                    self.border_radius
+                )
+                sdf.fill_keep(body)
+
+                sdf.stroke(
+                    border_color,
+                    border_width
+                )
+                return sdf.result
+            }
+        }
+    }
+
+    UpdateCloseButton = <MolyButton> {
+        width: Fit,
+        height: Fit,
+
+        margin: {top: -8}
+
+        draw_icon: {
+            svg_file: (ICON_CLOSE),
+            fn get_color(self) -> vec4 {
+                return #000;
+            }
+        }
+        icon_walk: {width: 10, height: 10}
+    }
+
+    UpdateIcon = <View> {
+        width: Fit,
+        height: Fit,
+        margin: {top: -10, left: -10}
+        update_icon = <View> {
+            width: Fit,
+            height: Fit,
+            <Image> {
+                source: (UPDATE_ICON),
+                width: 35,
+                height: 35,
+            }
+        }
+    }
+
+    UpdateContent = <View> {
+        width: Fill,
+        height: Fit,
+        flow: Down,
+        spacing: 10
+
+        title = <Label> {
+            draw_text:{
+                text_style: <BOLD_FONT>{font_size: 9},
+                word: Wrap,
+                color: #000
+            }
+            text: "New update available"
+        }
+
+        summary = <Label> {
+            width: Fill,
+            draw_text:{
+                text_style: <REGULAR_FONT>{font_size: 9},
+                word: Wrap,
+                color: #000
+            }
+            text: ""
+        }
+
+        actions = <View> {
+            width: Fit,
+            height: Fit,
+            spacing: 10,
+
+            download_button = <MolyButton> {
+                text: "Download update"
+                draw_text: {
+                    color: #000
+                    text_style: <BOLD_FONT>{font_size: 9}
+                }
+            }
+
+            later_button = <MolyButton> {
+                text: "Later"
+                draw_text: {
+                    color: #000
+                    text_style: <BOLD_FONT>{font_size: 9}
+                }
+            }
+        }
+    }
+
+    pub UpdateNotificationPopup = {{UpdateNotificationPopup}} {
+        width: Fit
+        height: Fit
+
+        <UpdatePopupDialog> {
+            <UpdateIcon> {}
+            <UpdateContent> {}
+            close_button = <UpdateCloseButton> {}
+        }
+    }
+}
+
+#[derive(Clone, Debug, DefaultNone)]
+pub enum UpdateNotificationPopupAction {
+    None,
+    CloseButtonClicked,
+    OpenReleasePage,
+}
+
+#[derive(Live, LiveHook, Widget)]
+pub struct UpdateNotificationPopup {
+    #[deref]
+    view: View,
+
+    #[layout]
+    layout: Layout,
+
+    #[rust]
+    version: Option<String>,
+}
+
+impl Widget for UpdateNotificationPopup {
+    fn handle_event(&mut self, cx: &mut Cx, event: &Event, scope: &mut Scope) {
+        self.view.handle_event(cx, event, scope);
+        self.widget_match_event(cx, event, scope);
+    }
+
+    fn draw_walk(&mut self, cx: &mut Cx2d, scope: &mut Scope, walk: Walk) -> DrawStep {
+        let _ = self
+            .view
+            .draw_walk(cx, scope, walk.with_abs_pos(DVec2 { x: 0., y: 0. }));
+
+        DrawStep::done()
+    }
+}
+
+impl WidgetMatchEvent for UpdateNotificationPopup {
+    fn handle_actions(&mut self, cx: &mut Cx, actions: &Actions, _scope: &mut Scope) {
+        if self.button(ids!(close_button)).clicked(actions) {
+            cx.action(UpdateNotificationPopupAction::CloseButtonClicked);
+        }
+
+        if self.button(ids!(download_button)).clicked(actions) {
+            cx.action(UpdateNotificationPopupAction::OpenReleasePage);
+        }
+
+        if self.button(ids!(later_button)).clicked(actions) {
+            cx.action(UpdateNotificationPopupAction::CloseButtonClicked);
+        }
+    }
+}
+
+impl UpdateNotificationPopup {
+    pub fn set_version(&mut self, cx: &mut Cx, version: &str) {
+        self.version = Some(version.to_string());
+        let summary = match &self.version {
+            Some(v) => format!("Version {v} is available. Download the latest release to update."),
+            None => "A new version is available.".to_string(),
+        };
+
+        self.label(ids!(summary)).set_text(cx, &summary);
+    }
+}
+
+impl UpdateNotificationPopupRef {
+    pub fn set_version(&mut self, cx: &mut Cx, version: &str) {
+        if let Some(mut inner) = self.borrow_mut() {
+            inner.set_version(cx, version);
+        }
+    }
+}

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,54 @@
+//! Minimal updater helper using CrabNebula's `cargo-packager-updater`.
+//! Replace `UPDATER_PUBKEY` with the minisign public key that matches the
+//! private key configured in the release pipeline.
+
+use anyhow::Result;
+use cargo_packager_updater::{check_update, Config};
+use makepad_widgets::*;
+
+/// Minisign public key that verifies update signatures.
+/// TODO: replace with the real public key (e.g. `RWQ...`).
+// const UPDATER_PUBKEY: &str = "REPLACE_WITH_MINISIGN_PUBLIC_KEY";
+const UPDATER_PUBKEY: &str = "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEFGOTlFM0UzMTZCNUQzMTUKUldRVjA3VVc0K09acnhYRFU3My9wK1BuV2ZOeElNT1M4RWIvb1ZDSktrTHU5bkJmMUthZkdKUWoK";
+
+/// Action emitted back into Makepad once an update check finishes.
+#[derive(Clone, Debug, DefaultNone)]
+pub enum UpdaterAction {
+    UpdateAvailable(String),
+    NoUpdate,
+    Failed(String),
+    None,
+}
+
+/// Checks GitHub Releases for an available update without blocking the UI thread.
+///
+/// This queries the `latest` release endpoint using target/arch-specific
+/// manifests uploaded by the release workflow (e.g. `latest-windows-x86_64.json`).
+/// When finished, it posts a [`UpdaterAction`] into the Makepad event queue so the UI
+/// can react without the startup path blocking on network I/O.
+pub async fn check_moly_update() -> Result<()> {
+    let current_version = env!("CARGO_PKG_VERSION").parse()?;
+    let config = Config {
+        endpoints: vec![ "https://github.com/tyreseluo/moly/releases/latest/download/latest-{{target}}-{{arch}}.json".parse()? ],
+        pubkey: UPDATER_PUBKEY.into(),
+        ..Default::default()
+    };
+
+    let update_result = tokio::task::spawn_blocking(move || check_update(current_version, config))
+        .await?;
+
+    match update_result {
+        Ok(Some(update)) => {
+            Cx::post_action(UpdaterAction::UpdateAvailable(update.version.to_string()));
+        }
+        Ok(None) => {
+            Cx::post_action(UpdaterAction::NoUpdate);
+        }
+        Err(err) => {
+            Cx::post_action(UpdaterAction::Failed(err.to_string()));
+            return Err(err.into());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## PR content

> PR status: work in progress.

Use `cargo-packager-updater` to fetch latest moly version, if moly has new version, will popup a update notification modal.

Ideal functionality: When clicked, it should not redirect to the latest GitHub release pages. Instead, it should download directly in the background. After the file is saved to disk, prompting the app to restart completes the update.

## Related PR

- https://github.com/moly-ai/moly-ai/issues/519
