### PR TITLE
fix: Fix OpenClaw integration issues after #636 merge

### DIFF
--- a/src/data/openclaw_client.rs
+++ b/src/data/openclaw_client.rs
@@ -293,7 +293,12 @@ fn process_event(
         }
         "agent.error" => {
             let msg = payload
-                .and_then(|p| p["message"].as_str().or(p["error"].as_str()))
+                .and_then(|p| {
+                    p["errorMessage"]
+                        .as_str()
+                        .or_else(|| p["message"].as_str())
+                        .or_else(|| p["error"].as_str())
+                })
                 .unwrap_or("Unknown error");
             ProcessResult::Error(ClientError::new(
                 ClientErrorKind::Response,
@@ -315,7 +320,10 @@ fn process_response(
 ) -> ProcessResult {
     let ok = json["ok"].as_bool().unwrap_or(false);
     if !ok {
-        let msg = json["error"].as_str().unwrap_or("Unknown error");
+        let msg = json["errorMessage"]
+            .as_str()
+            .or_else(|| json["error"].as_str())
+            .unwrap_or("Unknown error");
         return ProcessResult::Error(ClientError::new(
             ClientErrorKind::Response,
             format!("OpenClaw error: {}", msg),

--- a/src/data/supported_providers.json
+++ b/src/data/supported_providers.json
@@ -158,7 +158,7 @@
             "url": "ws://127.0.0.1:18789",
             "provider_type": "OpenClaw",
             "supported_models": [
-                "OpenClaw Assistant"
+                "openclaw/assistant"
             ]
         }
     ]

--- a/src/settings/provider_view.rs
+++ b/src/settings/provider_view.rs
@@ -579,8 +579,9 @@ impl Widget for ProviderView {
             self.view(ids!(refresh_button)).set_visible(cx, false);
         }
 
+        let show_models = has_models && self.provider.provider_type != ProviderType::OpenClaw;
         self.view(ids!(provider_features_group))
-            .set_visible(cx, has_models);
+            .set_visible(cx, show_models);
 
         self.button(ids!(show_others_button))
             .set_visible(cx, show_others_button);


### PR DESCRIPTION
## Summary

- **Fix bot disabled by default**: `supported_providers.json` used display name (`"OpenClaw Assistant"`) instead of bot ID (`"openclaw/assistant"`). After #636 changed matching logic from `bot.name` to `bot.id`, the model no longer matched the whitelist, causing it to be disabled and showing "No models available".
- **Fix error message loss**: OpenClaw protocol returns errors in `errorMessage` field, but the client only read `error`, causing all errors to display as "Unknown error" instead of the actual message (e.g., `missing scope: operator.write`).
- **Hide models selector for OpenClaw**: Model selection is managed by the OpenClaw Gateway, not by Moly. The models selector in the provider settings is unnecessary and confusing for OpenClaw.

## Test plan
- [x] Verified OpenClaw bot is enabled by default after fix
- [x] Verified error messages display correctly (e.g., scope errors)
- [x] Verified models selector is hidden for OpenClaw provider
- [x] Verified other providers are unaffected